### PR TITLE
Use Coveralls service for code coverage

### DIFF
--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -92,4 +92,6 @@ jobs:
           path: ${{env.PYTHON_PATH}}
       # The following step is the central step to this job
       - name: Run tests
-        run: invoke test
+        env:
+            GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: invoke test --coverage=upload

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ invoke = "*"
 black = "==20.8b1"
 pytest = "*"
 coverage = "*"
+coveralls = "*"
 
 [packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "61709624064ca9c423e9d9a14793e3a99c49f99b816902c017eb227faf741718"
+            "sha256": "46c3a2f42833a8673a0df744982ea7d86cde00a9134fa430c13c04c4f417abf8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,11 +34,24 @@
         },
         "black": {
             "hashes": [
-                "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea",
-                "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"
+                "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"
             ],
             "index": "pypi",
             "version": "==20.8b1"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+            ],
+            "version": "==2020.6.20"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
         },
         "click": {
             "hashes": [
@@ -87,6 +100,28 @@
             ],
             "index": "pypi",
             "version": "==5.3"
+        },
+        "coveralls": {
+            "hashes": [
+                "sha256:4430b862baabb3cf090d36d84d331966615e4288d8a8c5957e0fd456d0dd8bd6",
+                "sha256:b3b60c17b03a0dee61952a91aed6f131e0b2ac8bd5da909389c53137811409e1"
+            ],
+            "index": "pypi",
+            "version": "==2.1.2"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "iniconfig": {
             "hashes": [
@@ -192,6 +227,14 @@
             ],
             "version": "==2020.7.14"
         },
+        "requests": {
+            "hashes": [
+                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
+                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.24.0"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
@@ -240,6 +283,14 @@
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
             "version": "==3.7.4.3"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.25.10"
         }
     }
 }

--- a/tasks.py
+++ b/tasks.py
@@ -34,6 +34,10 @@ def test(context, coverage=None):
     if coverage == "write":
         # Write coverage report to file, ignore threshold
         failed = execute("coverage html --fail-under=0") or failed
+    elif coverage == "upload":
+        # Upload coverage; fails if not run in GitHub Actions context
+        print()
+        failed = execute("coveralls") or failed
     failed = execute("rm .coverage") or failed
     sys.exit(failed)
 


### PR DESCRIPTION
- Adds `coveralls` Python client to dev dependencies
- Adds coveralls `--coverage=upload` option to `test` task
- Adds the upload option to the GitHub Actions `Test` job