### PR TITLE
Direction list order

### DIFF
--- a/gaslines/utility.py
+++ b/gaslines/utility.py
@@ -4,6 +4,8 @@ from enum import Enum
 class Direction(Enum):
     """
     Two-dimensional vectors representing the four cardinal directions
+
+    It is expected that the order listed here is preserved
     """
 
     NORTH = (-1, 0)

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -7,3 +7,12 @@ def test_direction_returns_valid_direction():
     assert Direction.EAST.value == (0, 1)
     assert Direction.SOUTH.value == (1, 0)
     assert Direction.WEST.value == (0, -1)
+
+
+def test_list_returns_expected_direction_order():
+    assert list(Direction) == [
+        Direction.NORTH,
+        Direction.EAST,
+        Direction.SOUTH,
+        Direction.WEST,
+    ]


### PR DESCRIPTION
Adds a test that verifies that direction list order is preserved and specifies that this is expected in the docs