### PR TITLE
Remaining segments on points

### DIFF
--- a/gaslines/point.py
+++ b/gaslines/point.py
@@ -103,3 +103,37 @@ class Point:
         Sink points always display as open
         """
         return not self.is_source() and not self.has_parent()
+
+    def is_on_new_segment(self):
+        """
+        Helper method used by get_remaining_segments to determine whether this is the
+        beginning of a new straight line segment along the directed path from source
+        to sink
+
+        Exception: the first segment after a source point is considered a "freebie"
+
+        Example: consider the following two partial paths.
+
+        a--->b--->c
+
+        a--->b
+             |
+             v
+             c
+
+        In the first path, this method would say that the point labeled "c" is not on
+        a new line segment, because the segment that that point is on extends at least
+        as far back as point "a". In contrast, this method would say that "c" is on a
+        new segment in the second path, because the path bends immediately prior to
+        encountering point "c".
+        """
+        # Sources and open nodes (including sinks) are irrelevant
+        if not self.has_parent():
+            return False
+        parent = self.parent
+        # The first segment after a source point is considered a "freebie"
+        if not parent.has_parent():
+            return False
+        # Check whether this is in a different row from its grandparent
+        # Use of row over column was an arbitrary decision
+        return abs(parent.parent.row_index - self.row_index) == 1

--- a/gaslines/point.py
+++ b/gaslines/point.py
@@ -137,3 +137,17 @@ class Point:
         # Check whether this is in a different row from its grandparent
         # Use of row over column was an arbitrary decision
         return abs(parent.parent.row_index - self.row_index) == 1
+
+    def get_remaining_segments(self):
+        """
+        Returns the exact number of remaining straight line segments required to
+        connect this point to a sink
+        """
+        # It doesn't make sense to request the remaining segments of an open point
+        if self.is_open():
+            return None
+        # Base case: number of remaining segments is fixed if the point is a source
+        if self.is_source():
+            return self._type
+        # Recursive case: remaining segments of parent, minus one if on new segment
+        return self.parent.get_remaining_segments() - self.is_on_new_segment()

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -181,3 +181,61 @@ def test_is_open_with_pipe_conditional_on_parent():
     # Test pipe with parent is not open
     grid[0][0].child = pipe
     assert not pipe.is_open()
+
+
+def test_is_on_new_segment_with_source_returns_false():
+    grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
+    assert not grid[0][0].is_on_new_segment()
+    assert not grid[2][0].is_on_new_segment()
+
+
+def test_is_on_new_segment_with_open_point_returns_false():
+    grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
+    assert not grid[0][1].is_on_new_segment()
+    assert not grid[1][1].is_on_new_segment()
+    assert not grid[1][2].is_on_new_segment()
+
+
+def test_is_on_new_segment_with_sink_returns_false():
+    grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
+    sink = grid[2][2]
+    # Test sink with no parents
+    assert not sink.is_on_new_segment()
+    # Test sink with one parent
+    grid[0][0].child = grid[0][1]
+    grid[0][1].child = grid[0][2]
+    grid[0][2].child = grid[1][2]
+    grid[1][2].child = sink
+    assert not sink.is_on_new_segment()
+    # Test sink with all parents
+    grid[2][0].child = grid[2][1]
+    grid[2][1].child = sink
+    assert not sink.is_on_new_segment()
+
+
+def test_is_on_new_segment_with_first_segment_returns_false():
+    grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
+    # Test first point on first segment
+    grid[0][0].child = grid[0][1]
+    assert not grid[0][1].is_on_new_segment()
+    # Test second point on first segment
+    grid[0][1].child = grid[0][2]
+    assert not grid[0][2].is_on_new_segment()
+
+
+def test_is_on_new_segment_with_new_segment_returns_true():
+    grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
+    point = grid[1][2]
+    grid[0][0].child = grid[0][1]
+    grid[0][1].child = grid[0][2]
+    grid[0][2].child = point
+    assert point.is_on_new_segment()
+
+
+def test_is_on_new_segment_with_old_segment_returns_false():
+    grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
+    point = grid[2][1]
+    grid[0][0].child = grid[0][1]
+    grid[0][1].child = grid[1][1]
+    grid[1][1].child = point
+    assert not point.is_on_new_segment()

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -239,3 +239,46 @@ def test_is_on_new_segment_with_old_segment_returns_false():
     grid[0][1].child = grid[1][1]
     grid[1][1].child = point
     assert not point.is_on_new_segment()
+
+
+def test_get_remaining_segments_with_source_returns_type():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    assert grid[0][0].get_remaining_segments() == grid[0][0]._type == 3
+    assert grid[1][1].get_remaining_segments() == grid[1][1]._type == 2
+
+
+def test_get_remaining_segments_with_open_point_returns_none():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    assert grid[0][1].get_remaining_segments() is None
+    assert grid[1][0].get_remaining_segments() is None
+    assert grid[2][1].get_remaining_segments() is None
+
+
+def test_get_remaining_segments_with_sink_returns_none():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    assert grid[2][0].get_remaining_segments() is None
+
+
+def test_get_remaining_segments_with_first_segment_returns_no_change():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    # Test first point on first segment
+    grid[0][0].child = grid[0][1]
+    assert grid[0][1].get_remaining_segments() == 3
+    # Test second point on first segment
+    grid[0][1].child = grid[0][2]
+    assert grid[0][2].get_remaining_segments() == 3
+
+
+def test_get_remaining_segments_with_new_segment_returns_change():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    # Test first point on second segment
+    grid[0][0].child = grid[0][1]
+    grid[0][1].child = grid[0][2]
+    grid[0][2].child = grid[1][2]
+    assert grid[1][2].get_remaining_segments() == 2
+    # Test second point on second segment has no change
+    grid[1][2].child = grid[2][2]
+    assert grid[2][2].get_remaining_segments() == 2
+    # Test first point on third segment
+    grid[2][2].child = grid[2][1]
+    assert grid[2][1].get_remaining_segments() == 1


### PR DESCRIPTION
Adds the `get_remaining_segments` method to the `Point` class, which determines the exact number of remaining straight line segments required to connect a given point to a sink. Internally, this relies on the `is_on_new_segment` method. Both methods are added with tests.