### PR TITLE
Point and Grid Unicode representations

### DIFF
--- a/gaslines/grid.py
+++ b/gaslines/grid.py
@@ -1,4 +1,5 @@
 from gaslines.point import Point
+from gaslines.utility import Direction
 
 
 class Grid:
@@ -27,3 +28,39 @@ class Grid:
     @property
     def length(self):
         return self._length
+
+    def __str__(self):
+        """
+        Returns a Unicode representation of the grid in its current state
+        """
+        lines = []
+        for row in self:
+            row_relationships, column_relationships = [], []
+            for point in row:
+                # Add a representation of the point and its eastern relationship
+                row_relationships.append(str(point))
+                row_relationships.append(Grid._get_row_relationship(point))
+                # Add a representation of the point's southern relationship
+                column_relationships.append(Grid._get_column_relationship(point))
+            # Concatenate row_relationships, discarding the excess row_relationship
+            lines.append("".join(row_relationships[:-1]))
+            # Concatenate column_relationships
+            lines.append("   ".join(column_relationships))
+        # Concatenate all lines, discarding the excess column_relationship
+        return "\n".join(lines[:-1])
+
+    @staticmethod
+    def _get_row_relationship(point):
+        """
+        Helper method that returns a Unicode representation of a point's eastern
+        relationship
+        """
+        return "---" if point.has_relationship(Direction.EAST) else "   "
+
+    @staticmethod
+    def _get_column_relationship(point):
+        """
+        Helper method that returns a Unicode representation of a point's southern
+        relationship
+        """
+        return "|" if point.has_relationship(Direction.SOUTH) else " "

--- a/gaslines/point.py
+++ b/gaslines/point.py
@@ -165,3 +165,17 @@ class Point:
             return self._type
         # Recursive case: remaining segments of parent, minus one if on new segment
         return self.parent.get_remaining_segments() - self.is_on_new_segment()
+
+    def __str__(self):
+        """
+        Returns a single Unicode character representation of the (type of) point
+
+        For sources, this character is a digit, representing the number of remaining
+        segments to connect that point to a sink
+        """
+        if self.is_sink():
+            return "*"
+        if self.is_source():
+            return str(self.get_remaining_segments())
+        # For pipe points, return the interpunct character, "·"
+        return chr(183)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -2,6 +2,23 @@ import pytest
 from gaslines.grid import Grid
 
 
+GRID_STRING_1 = """\
+3   ·   ·
+         
+·   2   ·
+         
+*   ·   ·\
+"""
+
+GRID_STRING_2 = """\
+3---·---·
+        |
+·---2   ·
+|       |
+*---·---·\
+"""
+
+
 @pytest.mark.parametrize(
     "input_grid", (((-1,), (-1,)), ((1, 0), (-1, -1)), ((-1,), (-1,), (-1,)))
 )
@@ -34,3 +51,23 @@ def test_subscripting_returns_correct_points():
     # Test that the third row only has sources
     for point in grid[2]:
         assert point.is_source()
+
+
+def test_str_with_empty_board_returns_correct_string():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    assert str(grid) == GRID_STRING_1
+
+
+def test_str_with_complete_board_returns_correct_string():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    # Set path from "3"
+    grid[0][0].child = grid[0][1]
+    grid[0][1].child = grid[0][2]
+    grid[0][2].child = grid[1][2]
+    grid[1][2].child = grid[2][2]
+    grid[2][2].child = grid[2][1]
+    grid[2][1].child = grid[2][0]
+    # Set path from "2"
+    grid[1][1].child = grid[1][0]
+    grid[1][0].child = grid[2][0]
+    assert str(grid) == GRID_STRING_2

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -322,3 +322,20 @@ def test_has_relationship_with_no_neighbor_returns_false():
     assert not grid[0][0].has_relationship(Direction.NORTH)
     assert not grid[0][0].has_relationship(Direction.WEST)
     assert not grid[0][1].has_relationship(Direction.NORTH)
+
+
+def test_str_with_source_returns_type():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    assert str(grid[0][0]) == "3"
+    assert str(grid[1][1]) == "2"
+
+
+def test_str_with_pipe_returns_interpunct():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    for i, j in ((0, 1), (0, 2), (1, 2), (2, 1)):
+        assert str(grid[i][j]) == chr(183) == "·"
+
+
+def test_str_with_sink_returns_asterisk():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    assert str(grid[2][0]) == "*"


### PR DESCRIPTION
Adds the `__str__` method to both the `Point` and `Grid` classes, which can now be used to print out visual representations of their instances. Also adds tests.