### PR TITLE
Convert get_remaining_segments into property

### DIFF
--- a/gaslines/point.py
+++ b/gaslines/point.py
@@ -129,7 +129,7 @@ class Point:
 
     def is_on_new_segment(self):
         """
-        Helper method used by get_remaining_segments to determine whether this is the
+        Helper method used by remaining_segments to determine whether this is the
         beginning of a new straight line segment along the directed path from source
         to sink
 
@@ -161,7 +161,8 @@ class Point:
         # Use of row over column was an arbitrary decision
         return abs(parent.parent.row_index - self.row_index) == 1
 
-    def get_remaining_segments(self):
+    @property
+    def remaining_segments(self):
         """
         Returns the exact number of remaining straight line segments required to
         connect this point to a sink
@@ -173,7 +174,7 @@ class Point:
         if self.is_source():
             return self._type
         # Recursive case: remaining segments of parent, minus one if on new segment
-        return self.parent.get_remaining_segments() - self.is_on_new_segment()
+        return self.parent.remaining_segments - self.is_on_new_segment()
 
     def __str__(self):
         """
@@ -185,6 +186,6 @@ class Point:
         if self.is_sink():
             return "*"
         if self.is_source():
-            return str(self.get_remaining_segments())
+            return str(self.remaining_segments)
         # For pipe points, return the interpunct character, "·"
         return chr(183)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -241,47 +241,47 @@ def test_is_on_new_segment_with_old_segment_returns_false():
     assert not point.is_on_new_segment()
 
 
-def test_get_remaining_segments_with_source_returns_type():
+def test_remaining_segments_with_source_returns_type():
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
-    assert grid[0][0].get_remaining_segments() == grid[0][0]._type == 3
-    assert grid[1][1].get_remaining_segments() == grid[1][1]._type == 2
+    assert grid[0][0].remaining_segments == grid[0][0]._type == 3
+    assert grid[1][1].remaining_segments == grid[1][1]._type == 2
 
 
-def test_get_remaining_segments_with_open_point_returns_none():
+def test_remaining_segments_with_open_point_returns_none():
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
-    assert grid[0][1].get_remaining_segments() is None
-    assert grid[1][0].get_remaining_segments() is None
-    assert grid[2][1].get_remaining_segments() is None
+    assert grid[0][1].remaining_segments is None
+    assert grid[1][0].remaining_segments is None
+    assert grid[2][1].remaining_segments is None
 
 
-def test_get_remaining_segments_with_sink_returns_none():
+def test_remaining_segments_with_sink_returns_none():
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
-    assert grid[2][0].get_remaining_segments() is None
+    assert grid[2][0].remaining_segments is None
 
 
-def test_get_remaining_segments_with_first_segment_returns_no_change():
+def test_remaining_segments_with_first_segment_returns_no_change():
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Test first point on first segment
     grid[0][0].child = grid[0][1]
-    assert grid[0][1].get_remaining_segments() == 3
+    assert grid[0][1].remaining_segments == 3
     # Test second point on first segment
     grid[0][1].child = grid[0][2]
-    assert grid[0][2].get_remaining_segments() == 3
+    assert grid[0][2].remaining_segments == 3
 
 
-def test_get_remaining_segments_with_new_segment_returns_change():
+def test_remaining_segments_with_new_segment_returns_change():
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Test first point on second segment
     grid[0][0].child = grid[0][1]
     grid[0][1].child = grid[0][2]
     grid[0][2].child = grid[1][2]
-    assert grid[1][2].get_remaining_segments() == 2
+    assert grid[1][2].remaining_segments == 2
     # Test second point on second segment has no change
     grid[1][2].child = grid[2][2]
-    assert grid[2][2].get_remaining_segments() == 2
+    assert grid[2][2].remaining_segments == 2
     # Test first point on third segment
     grid[2][2].child = grid[2][1]
-    assert grid[2][1].get_remaining_segments() == 1
+    assert grid[2][1].remaining_segments == 1
 
 
 def test_has_relationship_with_no_relationship_returns_false():


### PR DESCRIPTION
Converts the `get_remaining_segments()` method in the `Point` class into a property called `remaining_segments`, and updates accordingly everywhere that this is used.