### PR TITLE
Replace is_on_new_segment with is_on_different_segment

### DIFF
--- a/gaslines/point.py
+++ b/gaslines/point.py
@@ -127,7 +127,7 @@ class Point:
         """
         return not self.is_open() and not self.has_child()
 
-    def is_on_new_segment(self):
+    def is_on_different_segment(self):
         """
         Helper method used by remaining_segments to determine whether this is the
         beginning of a new straight line segment along the directed path from source
@@ -174,7 +174,7 @@ class Point:
         if self.is_source():
             return self._type
         # Recursive case: remaining segments of parent, minus one if on new segment
-        return self.parent.remaining_segments - self.is_on_new_segment()
+        return self.parent.remaining_segments - self.is_on_different_segment()
 
     def __str__(self):
         """

--- a/gaslines/point.py
+++ b/gaslines/point.py
@@ -129,31 +129,20 @@ class Point:
 
     def is_on_different_segment(self, neighbor):
         """
-        Helper method used by remaining_segments to determine whether this is the
-        beginning of a new straight line segment along the directed path from source
-        to sink
+        Determines whether this is on a different straight line segment from the given
+        neighbor, along the directed path from source to sink
 
-        Exception: the first segment after a source point is considered a "freebie"
+        Correct usage of this method presupposes that the neighbor provided either
+        has a single parent or is a source point
 
-        Example: consider the following two partial paths.
-
-        a--->b--->c
-
-        a--->b
-             |
-             v
-             c
-
-        In the first path, this method would say that the point labeled "c" is not on
-        a new line segment, because the segment that that point is on extends at least
-        as far back as point "a". In contrast, this method would say that "c" is on a
-        new segment in the second path, because the path bends immediately prior to
-        encountering point "c".
+        The child of a source point is not considered to be on a different segment
+        from its parent, even though its parent is not preceded by a segment
         """
         # The first segment after a source point is considered a "freebie"
+        # Non-source neighbors without parents are irrelevant
         if not neighbor.has_parent():
             return False
-        # Check whether this is in a different row from its grandparent
+        # Check whether this is in a different row from the parent of its neighbor
         # Use of row over column was an arbitrary decision
         return abs(neighbor.parent.row_index - self.row_index) == 1
 

--- a/gaslines/point.py
+++ b/gaslines/point.py
@@ -127,7 +127,7 @@ class Point:
         """
         return not self.is_open() and not self.has_child()
 
-    def is_on_different_segment(self):
+    def is_on_different_segment(self, neighbor):
         """
         Helper method used by remaining_segments to determine whether this is the
         beginning of a new straight line segment along the directed path from source
@@ -150,16 +150,12 @@ class Point:
         new segment in the second path, because the path bends immediately prior to
         encountering point "c".
         """
-        # Sources and open nodes (including sinks) are irrelevant
-        if not self.has_parent():
-            return False
-        parent = self.parent
         # The first segment after a source point is considered a "freebie"
-        if not parent.has_parent():
+        if not neighbor.has_parent():
             return False
         # Check whether this is in a different row from its grandparent
         # Use of row over column was an arbitrary decision
-        return abs(parent.parent.row_index - self.row_index) == 1
+        return abs(neighbor.parent.row_index - self.row_index) == 1
 
     @property
     def remaining_segments(self):
@@ -174,7 +170,8 @@ class Point:
         if self.is_source():
             return self._type
         # Recursive case: remaining segments of parent, minus one if on new segment
-        return self.parent.remaining_segments - self.is_on_different_segment()
+        parent = self.parent
+        return parent.remaining_segments - self.is_on_different_segment(parent)
 
     def __str__(self):
         """

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -185,60 +185,21 @@ def test_is_open_with_pipe_conditional_on_parent():
 
 def test_is_on_different_segment_with_source_returns_false():
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
-    assert not grid[0][0].is_on_different_segment()
-    assert not grid[2][0].is_on_different_segment()
+    source = grid[0][0]
+    assert not grid[0][1].is_on_different_segment(source)
+    assert not grid[1][0].is_on_different_segment(source)
 
 
-def test_is_on_different_segment_with_open_point_returns_false():
+def test_is_on_different_segment_with_same_segment_returns_true():
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
-    assert not grid[0][1].is_on_different_segment()
-    assert not grid[1][1].is_on_different_segment()
-    assert not grid[1][2].is_on_different_segment()
-
-
-def test_is_on_different_segment_with_sink_returns_false():
-    grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
-    sink = grid[2][2]
-    # Test sink with no parents
-    assert not sink.is_on_different_segment()
-    # Test sink with one parent
     grid[0][0].child = grid[0][1]
-    grid[0][1].child = grid[0][2]
-    grid[0][2].child = grid[1][2]
-    grid[1][2].child = sink
-    assert not sink.is_on_different_segment()
-    # Test sink with all parents
-    grid[2][0].child = grid[2][1]
-    grid[2][1].child = sink
-    assert not sink.is_on_different_segment()
+    assert grid[1][1].is_on_different_segment(grid[0][1])
 
 
-def test_is_on_different_segment_with_first_segment_returns_false():
+def test_is_on_different_segment_with_different_segment_returns_false():
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
-    # Test first point on first segment
     grid[0][0].child = grid[0][1]
-    assert not grid[0][1].is_on_different_segment()
-    # Test second point on first segment
-    grid[0][1].child = grid[0][2]
-    assert not grid[0][2].is_on_different_segment()
-
-
-def test_is_on_different_segment_with_new_segment_returns_true():
-    grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
-    point = grid[1][2]
-    grid[0][0].child = grid[0][1]
-    grid[0][1].child = grid[0][2]
-    grid[0][2].child = point
-    assert point.is_on_different_segment()
-
-
-def test_is_on_different_segment_with_old_segment_returns_false():
-    grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
-    point = grid[2][1]
-    grid[0][0].child = grid[0][1]
-    grid[0][1].child = grid[1][1]
-    grid[1][1].child = point
-    assert not point.is_on_different_segment()
+    assert not grid[0][2].is_on_different_segment(grid[0][1])
 
 
 def test_remaining_segments_with_source_returns_type():

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -183,62 +183,62 @@ def test_is_open_with_pipe_conditional_on_parent():
     assert not pipe.is_open()
 
 
-def test_is_on_new_segment_with_source_returns_false():
+def test_is_on_different_segment_with_source_returns_false():
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
-    assert not grid[0][0].is_on_new_segment()
-    assert not grid[2][0].is_on_new_segment()
+    assert not grid[0][0].is_on_different_segment()
+    assert not grid[2][0].is_on_different_segment()
 
 
-def test_is_on_new_segment_with_open_point_returns_false():
+def test_is_on_different_segment_with_open_point_returns_false():
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
-    assert not grid[0][1].is_on_new_segment()
-    assert not grid[1][1].is_on_new_segment()
-    assert not grid[1][2].is_on_new_segment()
+    assert not grid[0][1].is_on_different_segment()
+    assert not grid[1][1].is_on_different_segment()
+    assert not grid[1][2].is_on_different_segment()
 
 
-def test_is_on_new_segment_with_sink_returns_false():
+def test_is_on_different_segment_with_sink_returns_false():
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
     sink = grid[2][2]
     # Test sink with no parents
-    assert not sink.is_on_new_segment()
+    assert not sink.is_on_different_segment()
     # Test sink with one parent
     grid[0][0].child = grid[0][1]
     grid[0][1].child = grid[0][2]
     grid[0][2].child = grid[1][2]
     grid[1][2].child = sink
-    assert not sink.is_on_new_segment()
+    assert not sink.is_on_different_segment()
     # Test sink with all parents
     grid[2][0].child = grid[2][1]
     grid[2][1].child = sink
-    assert not sink.is_on_new_segment()
+    assert not sink.is_on_different_segment()
 
 
-def test_is_on_new_segment_with_first_segment_returns_false():
+def test_is_on_different_segment_with_first_segment_returns_false():
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
     # Test first point on first segment
     grid[0][0].child = grid[0][1]
-    assert not grid[0][1].is_on_new_segment()
+    assert not grid[0][1].is_on_different_segment()
     # Test second point on first segment
     grid[0][1].child = grid[0][2]
-    assert not grid[0][2].is_on_new_segment()
+    assert not grid[0][2].is_on_different_segment()
 
 
-def test_is_on_new_segment_with_new_segment_returns_true():
+def test_is_on_different_segment_with_new_segment_returns_true():
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
     point = grid[1][2]
     grid[0][0].child = grid[0][1]
     grid[0][1].child = grid[0][2]
     grid[0][2].child = point
-    assert point.is_on_new_segment()
+    assert point.is_on_different_segment()
 
 
-def test_is_on_new_segment_with_old_segment_returns_false():
+def test_is_on_different_segment_with_old_segment_returns_false():
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
     point = grid[2][1]
     grid[0][0].child = grid[0][1]
     grid[0][1].child = grid[1][1]
     grid[1][1].child = point
-    assert not point.is_on_new_segment()
+    assert not point.is_on_different_segment()
 
 
 def test_remaining_segments_with_source_returns_type():


### PR DESCRIPTION
Replaces the `is_on_new_segment` method in the `Point` class with the generalized `is_on_different_segment` method. While `is_on_new_segment` could only be used to check if a point was on a different segment from its parent, the `is_on_different_segment` method enables one to check if a point is on a different segment from any given neighbor, regardless of whether it is a parent of that point.

Since it is required that the parent of any point be one of its neighbors, the old statement `point.is_on_new_segment()` is equivalent to the new statement `point.is_on_different_segment(parent)`.

Also overhauls the `is_on_new_segment` tests with new `is_on_different_segment` tests.