### PR TITLE
Remove index wrapper function

### DIFF
--- a/gaslines/utility.py
+++ b/gaslines/utility.py
@@ -12,16 +12,3 @@ class Direction(Enum):
     EAST = (0, 1)
     SOUTH = (1, 0)
     WEST = (0, -1)
-
-
-def index(list_, value):
-    """
-    Returns the first index of the value if it is present and -1 otherwise.
-
-    This is a simple wrapper function for the list.index() method that, instead of
-    raising a ValueError if the value is absent, simply returns -1.
-    """
-    try:
-        return list_.index(value)
-    except ValueError:
-        return -1

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,6 +1,5 @@
 import pytest
 from gaslines.utility import Direction
-from gaslines.utility import index
 
 
 def test_direction_returns_valid_direction():
@@ -17,14 +16,3 @@ def test_list_returns_expected_direction_order():
         Direction.SOUTH,
         Direction.WEST,
     ]
-
-
-def test_index_with_value_present_returns_index():
-    list_ = ["a", "b", "c", "d"]
-    for i, value in enumerate(list_):
-        assert index(list_, value) == list_.index(value) == i
-
-
-def test_index_with_value_absent_returns_negative_one():
-    list_ = ["a", "b", "c", "d"]
-    assert index(list_, "e") == -1


### PR DESCRIPTION
Reverts andrewtbiehl/gaslines#24.

I originally thought that this helper function would be useful but I discovered a way to avoid using it without compromising conciseness and readability.