### PR TITLE
Solve module get_next function

### DIFF
--- a/gaslines/solve.py
+++ b/gaslines/solve.py
@@ -1,3 +1,21 @@
+def get_next(current):
+    """
+    Returns a valid neighbor of "current", in the current recursive state, that has
+    not yet been tried as its child, or None if all valid neighbors have been tried.
+    """
+    # Presumes that the order returned by get_neighbors is preserved over time
+    neighbors = current.get_neighbors()
+    # Get the index of the previously tested neighbor, the current child of "current"
+    child_index = -1 if not current.has_child() else neighbors.index(current.child)
+    # All untested neighbors occur strictly after the previously tested neighbor
+    untested_neighbors = neighbors[child_index + 1 :]
+    # Return the first of the untested neighbors that is worth considering
+    for neighbor in untested_neighbors:
+        if is_option(current, neighbor):
+            return neighbor
+    return None
+
+
 def is_option(current, neighbor):
     """
     Returns whether the neighbor is a valid option to be set as the child of current.

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -1,5 +1,5 @@
 from gaslines.grid import Grid
-from gaslines.solve import get_head, has_head, is_option
+from gaslines.solve import get_head, has_head, is_option, get_next
 
 
 def test_get_head_with_new_puzzle_returns_head():
@@ -116,3 +116,62 @@ def test_is_option_with_sink_and_greater_than_two_remaining_segments_returns_fal
     assert not is_option(current, grid[0][1])
     # Test sink on new segment
     assert not is_option(current, grid[1][2])
+
+
+def test_get_next_with_no_child_and_all_open_neighbors_returns_first_available():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    assert get_next(grid[0][0]).location == (0, 1)
+    assert get_next(grid[1][1]).location == (0, 1)
+
+
+def test_get_next_with_no_child_and_some_open_neighbors_returns_first_available():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    # Set partial path from "3"
+    grid[0][0].child = grid[0][1]
+    grid[0][1].child = grid[0][2]
+    grid[0][2].child = grid[1][2]
+    assert get_next(grid[1][1]).location == (2, 1)
+
+
+def test_get_next_with_no_child_and_no_open_neighbors_returns_none():
+    grid = Grid(((4, -1, 1), (0, -1, -1), (-1, -1, 0)))
+    # Set (incorrect) path from "4"
+    grid[0][0].child = grid[0][1]
+    grid[0][1].child = grid[1][1]
+    grid[1][1].child = grid[1][2]
+    grid[1][2].child = grid[2][2]
+    assert get_next(grid[1][2]) is None
+
+
+def test_get_next_with_one_remaining_segment_skips_point_on_new_segment():
+    grid = Grid(((-1, -1, -1, -1), (1, -1, -1, 0)))
+    grid[1][0].child = grid[1][1]
+    assert get_next(grid[1][1]).location == (1, 2)
+
+
+def test_get_next_with_two_remaining_segments_skips_sink_on_same_segment():
+    grid = Grid(((2, -1, 0), (-1, 0, -1)))
+    current = grid[0][1]
+    # Set partial path to current
+    grid[0][0].child = current
+    assert get_next(current).location == (1, 1)
+
+
+def test_get_next_with_greater_than_two_remaining_segments_skips_sinks():
+    grid = Grid(((-1, 0, -1), (4, -1, 0), (-1, -1, -1)))
+    current = grid[1][1]
+    # Set partial path to current
+    grid[1][0].child = current
+    assert get_next(current).location == (2, 1)
+
+
+def test_get_next_with_first_of_multiple_children_returns_next_child():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    grid[1][1].child = grid[0][1]
+    assert get_next(grid[1][1]).location == (1, 2)
+
+
+def test_get_next_with_last_child_returns_none():
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    grid[1][1].child = grid[1][0]
+    assert get_next(grid[1][1]) is None


### PR DESCRIPTION
Adds the `get_next` function to the `solve.py` module, as well as tests.

This function takes as a parameter a point called `current` and returns a (valid) neighbor of `current`, in the context of the current recursive state, that not yet been tried as its child, or `None` if all valid neighbors have been tried. This function is a helper function that will be used while searching for a solution to the current puzzle.