### PR TITLE
Add display module 

### DIFF
--- a/gaslines/display.py
+++ b/gaslines/display.py
@@ -1,3 +1,15 @@
+def print_and_backtrack(string):
+    """
+    On a standard terminal, clears everything below the cursor, prints the given
+    string, and then returns the cursor to its prior location.
+    """
+    Cursor.clear_below()
+    print(string)
+    # Backtrack the cursor as many new lines as were printed
+    number_of_lines = len(string.split("\n"))
+    Cursor.move_up(number_of_lines)
+
+
 class Cursor:
     """
     Static class that holds functions that wrap more complex interactions with a

--- a/gaslines/display.py
+++ b/gaslines/display.py
@@ -1,0 +1,30 @@
+class Cursor:
+    """
+    Static class that holds functions that wrap more complex interactions with a
+    standard terminal.
+    """
+
+    # Credit to the blessings terminal library, the inspection of which helped with
+    # the implementation of these methods
+
+    @staticmethod
+    def move_up(number_of_rows):
+        """
+        Moves the terminal cursor up from its current location the number of rows
+        specified.
+
+        Args:
+            number_of_rows (int): The number of rows to move up. Negative values are
+                ignored.
+        """
+        if number_of_rows > 0:
+            # Prints a particular ANSI escape code for the desired outcome
+            print(f"\x1b[{number_of_rows}A", end="")
+
+    @staticmethod
+    def clear_below():
+        """
+        Clears all rows below the cursor's current location (inclusive).
+        """
+        # Prints a particular ANSI escape code for the desired outcome
+        print("\x1b[J", end="")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,5 +1,23 @@
-from gaslines.display import Cursor
+from gaslines.display import Cursor, print_and_backtrack
 import pytest
+
+
+UNSOLVED_GRID_STRING = """\
+3   ·   ·
+         
+·   2   ·
+         
+*   ·   ·\
+"""
+
+
+SOLVED_GRID_STRING = """\
+3---·---·
+        |
+·---2   ·
+|       |
+*---·---·\
+"""
 
 
 # Note: these automated tests merely verify that the functions under test behave
@@ -22,3 +40,12 @@ def test_move_up_with_non_positive_number_does_nothing(capsys, number_of_rows):
 def test_clear_below_prints_correct_code(capsys):
     Cursor.clear_below()
     assert capsys.readouterr().out == "\x1b[J"
+
+
+@pytest.mark.parametrize(
+    "input_", ("", "test", UNSOLVED_GRID_STRING, SOLVED_GRID_STRING)
+)
+def test_print_and_backtrack_with_various_inputs_prints_correctly(capsys, input_):
+    lines = len(input_.split("\n"))
+    print_and_backtrack(input_)
+    assert capsys.readouterr().out == f"\x1b[J{input_}\n\x1b[{lines}A"

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,24 @@
+from gaslines.display import Cursor
+import pytest
+
+
+# Note: these automated tests merely verify that the functions under test behave
+# consistently. Given the functions' visual nature, verification of correct behavior
+# initially required manual testing.
+
+
+@pytest.mark.parametrize("number_of_rows", (1, 2, 11, 101))
+def test_move_up_with_positive_number_prints_correct_code(capsys, number_of_rows):
+    Cursor.move_up(number_of_rows)
+    assert capsys.readouterr().out == f"\x1b[{number_of_rows}A"
+
+
+@pytest.mark.parametrize("number_of_rows", (0, -1, -2, -11, -101))
+def test_move_up_with_non_positive_number_does_nothing(capsys, number_of_rows):
+    Cursor.move_up(number_of_rows)
+    assert capsys.readouterr().out == ""
+
+
+def test_clear_below_prints_correct_code(capsys):
+    Cursor.clear_below()
+    assert capsys.readouterr().out == "\x1b[J"


### PR DESCRIPTION
Adds the `display.py` module, including some new functions and associated tests. 

The `display.py` module is intended to hold all functions related to visual interfacing. This currently includes the `Cursor` class and `print_and_backtrack` function.
