### PR TITLE
Redistribute print_and_backtrack responsibilities

### DIFF
--- a/gaslines/display.py
+++ b/gaslines/display.py
@@ -1,15 +1,3 @@
-def print_and_backtrack(string):
-    """
-    On a standard terminal, clears everything below the cursor, prints the given
-    string, and then returns the cursor to its prior location.
-    """
-    Cursor.clear_below()
-    print(string)
-    # Backtrack the cursor as many new lines as were printed
-    number_of_lines = len(string.split("\n"))
-    Cursor.move_up(number_of_lines)
-
-
 class Cursor:
     """
     Static class that holds functions that wrap more complex interactions with a

--- a/gaslines/utility.py
+++ b/gaslines/utility.py
@@ -12,3 +12,15 @@ class Direction(Enum):
     EAST = (0, 1)
     SOUTH = (1, 0)
     WEST = (0, -1)
+
+
+def get_number_of_rows(string):
+    """
+    Determines the number of rows (a.k.a. lines) contained in the given string. This
+    is equivalent to counting one more than the number of newline characters in the
+    string.
+
+    Args:
+        string (str): The string whose rows are to be counted.
+    """
+    return len(string.split("\n"))

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,23 +1,5 @@
-from gaslines.display import Cursor, print_and_backtrack
+from gaslines.display import Cursor
 import pytest
-
-
-UNSOLVED_GRID_STRING = """\
-3   ·   ·
-         
-·   2   ·
-         
-*   ·   ·\
-"""
-
-
-SOLVED_GRID_STRING = """\
-3---·---·
-        |
-·---2   ·
-|       |
-*---·---·\
-"""
 
 
 # Note: these automated tests merely verify that the functions under test behave
@@ -40,12 +22,3 @@ def test_move_up_with_non_positive_number_does_nothing(capsys, number_of_rows):
 def test_clear_below_prints_correct_code(capsys):
     Cursor.clear_below()
     assert capsys.readouterr().out == "\x1b[J"
-
-
-@pytest.mark.parametrize(
-    "input_", ("", "test", UNSOLVED_GRID_STRING, SOLVED_GRID_STRING)
-)
-def test_print_and_backtrack_with_various_inputs_prints_correctly(capsys, input_):
-    lines = len(input_.split("\n"))
-    print_and_backtrack(input_)
-    assert capsys.readouterr().out == f"\x1b[J{input_}\n\x1b[{lines}A"

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,5 +1,14 @@
 import pytest
-from gaslines.utility import Direction
+from gaslines.utility import Direction, get_number_of_rows
+
+
+UNSOLVED_GRID_STRING = """\
+3   ·   ·
+         
+·   2   ·
+         
+*   ·   ·\
+"""
 
 
 def test_direction_returns_valid_direction():
@@ -16,3 +25,13 @@ def test_list_returns_expected_direction_order():
         Direction.SOUTH,
         Direction.WEST,
     ]
+
+
+@pytest.mark.parametrize(
+    "input_string,expected_number",
+    (("", 1), ("a", 1), ("\n", 2), ("a\nb\nc", 3), (UNSOLVED_GRID_STRING, 5)),
+)
+def test_get_number_of_rows_with_input_string_returns_expected_number(
+    input_string, expected_number
+):
+    assert get_number_of_rows(input_string) == expected_number


### PR DESCRIPTION
Removes the `print_and_backtrack` function, delegating its responsibilities to the `print` function, `Cursor.move_up` method, and the new `get_number_of_rows` function.

The `print_and_backtrack` function arguably violates the [single-responsibility principle](https://en.wikipedia.org/wiki/Single-responsibility_principle), hence the decision to break it apart into smaller units.
