### PR TITLE
Display module "reveal" strategy wrapper

### DIFF
--- a/gaslines/display.py
+++ b/gaslines/display.py
@@ -1,3 +1,32 @@
+from gaslines.utility import get_number_of_rows
+from gaslines.solve import has_head
+import time
+
+
+def reveal(strategy, delay):
+    """
+    Wraps the given strategy function with the additional functionality of displaying
+    intermediate search results in real time while solving a given Gas Lines grid.
+
+    Args:
+        strategy (Strategy class method): An algorithm for solving a Gas Lines grid.
+        delay (float): Amount of time (in seconds) to artificially delay between each
+            intermediate stage of the search.
+    """
+
+    def wrapper(grid, *args, **kwargs):
+        grid_image = str(grid)
+        # Clear all rows below the cursor, print the grid, pause, and then backtrack
+        Cursor.clear_below()
+        print(grid_image)
+        time.sleep(delay)
+        if has_head(grid):
+            Cursor.move_up(get_number_of_rows(grid_image))
+        return strategy(grid, *args, **kwargs)
+
+    return wrapper
+
+
 class Cursor:
     """
     Static class that holds functions that wrap more complex interactions with a

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,10 +1,29 @@
-from gaslines.display import Cursor
+from gaslines.display import Cursor, reveal
+from gaslines.grid import Grid
 import pytest
 
 
 # Note: these automated tests merely verify that the functions under test behave
 # consistently. Given the functions' visual nature, verification of correct behavior
 # initially required manual testing.
+
+
+UNSOLVED_GRID_STRING = """\
+3   ·   ·
+         
+·   2   ·
+         
+*   ·   ·\
+"""
+
+
+SOLVED_GRID_STRING = """\
+3---·---·
+        |
+·---2   ·
+|       |
+*---·---·\
+"""
 
 
 @pytest.mark.parametrize("number_of_rows", (1, 2, 11, 101))
@@ -22,3 +41,34 @@ def test_move_up_with_non_positive_number_does_nothing(capsys, number_of_rows):
 def test_clear_below_prints_correct_code(capsys):
     Cursor.clear_below()
     assert capsys.readouterr().out == "\x1b[J"
+
+
+def test_reveal_with_incomplete_puzzle_prints_and_backtracks(capsys):
+    # Mock out strategy function, set no delay, and use unsolved puzzle
+    strategy = lambda grid: None
+    delay = 0
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    # Method under test
+    reveal(strategy, delay)(grid)
+    assert capsys.readouterr().out == f"\x1b[J{UNSOLVED_GRID_STRING}\n\x1b[5A"
+
+
+def test_reveal_with_complete_puzzle_prints_but_does_not_backtrack(capsys):
+    # Mock out strategy function and set no delay
+    strategy = lambda grid: None
+    delay = 0
+    # Use solved puzzle
+    grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
+    # Set path from "3"
+    grid[0][0].child = grid[0][1]
+    grid[0][1].child = grid[0][2]
+    grid[0][2].child = grid[1][2]
+    grid[1][2].child = grid[2][2]
+    grid[2][2].child = grid[2][1]
+    grid[2][1].child = grid[2][0]
+    # Set path from "2"
+    grid[1][1].child = grid[1][0]
+    grid[1][0].child = grid[2][0]
+    # Method under test
+    reveal(strategy, delay)(grid)
+    assert capsys.readouterr().out == f"\x1b[J{SOLVED_GRID_STRING}\n"


### PR DESCRIPTION
Adds the `reveal` function to the `display.py` module, as well as tests.

This function takes as parameters `strategy`, a `Strategy` class method and `delay`, a (non-negative) numeric value, and wraps an instance of the method so that it reveals (i.e. prints) its intermediate work as it attempts to solve a Gas Lines puzzle. This provides a nice visual depiction of how the given algorithm actually solves the puzzle.