### PR TITLE
Add "reveal" functionality to "solve" function

### DIFF
--- a/gaslines/solve.py
+++ b/gaslines/solve.py
@@ -1,3 +1,6 @@
+import gaslines.display as display
+
+
 class Strategy:
     """
     Container class for algorithms that solve Gas Lines puzzles.
@@ -73,7 +76,7 @@ class Strategy:
 # to avoid a NameError
 
 
-def solve(grid, strategy=Strategy.full_recursive):
+def solve(grid, strategy=Strategy.full_recursive, reveal_delay=None):
     """
     Solves a Gas Lines puzzle (using the strategy provided).
 
@@ -84,6 +87,9 @@ def solve(grid, strategy=Strategy.full_recursive):
         grid (Grid): A (presumably unsolved) Gas Lines grid.
         strategy (Strategy class method): The choice of algorithm with which to solve
             the grid. Defaults to the "full_recursive" strategy.
+        reveal_delay (float, NoneType): If not None, displays intermediate stages of
+            the search, pausing between each stage for the given number of seconds.
+            Defaults to None.
 
     Returns:
         bool: Whether the grid has a solution.
@@ -91,6 +97,10 @@ def solve(grid, strategy=Strategy.full_recursive):
     strategy_name = strategy.__name__
     strategy_container = Strategy()
     solve = getattr(strategy_container, strategy_name)
+    # Optionally decorate the algorithm with reveal functionality
+    if reveal_delay is not None:
+        solve = display.reveal(solve, reveal_delay)
+        setattr(strategy_container, strategy_name, solve)
     return solve(grid)
 
 

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -3,6 +3,24 @@ from gaslines.solve import get_head, has_head, is_option, get_next, Strategy, so
 import pytest
 
 
+REVEAL_SEARCH_STRING = """\
+\x1b[J\
+2   ·
+     
+*   *
+\x1b[3A\
+\x1b[J\
+2---·
+     
+*   *
+\x1b[3A\
+\x1b[J\
+2---·
+    |
+*   *
+"""
+
+
 def test_get_head_with_new_puzzle_returns_head():
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert has_head(grid)
@@ -353,3 +371,12 @@ def test_solve_with_real_august_9_example_solves_grid(strategy):
     assert grid[6][4].child.location == (6, 3)
     assert grid[6][5].child.location == (6, 4)
     assert grid[6][6].child.location == (6, 5)
+
+
+@pytest.mark.parametrize(
+    "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
+)
+def test_solve_with_reveal_delay_activated_prints_accordingly(strategy, capsys):
+    grid = Grid(((2, -1), (0, 0)))
+    assert solve(grid, strategy, reveal_delay=0)
+    assert capsys.readouterr().out == REVEAL_SEARCH_STRING


### PR DESCRIPTION
Adds the functionality from the `reveal` wrapper function (see PR #32) to the `solve` function in the form of the `reveal_delay` parameter. Also adds tests.

The purpose of this additional functionality is to reveal (i.e. print) the intermediate work of a Gas Lines algorithm as it attempts to solve a puzzle.