### PR TITLE
Full GitHub Actions version numbers

### DIFF
--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -31,7 +31,7 @@ jobs:
           echo "PYTHON_PATH=${PYTHON_PATH}" >> ${GITHUB_ENV}
       - name: Restore project Python cache
         id: restore-project-python-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           key: ${{env.PYTHON_CACHE_KEY}}
           path: ${{env.PYTHON_PATH}}
@@ -60,7 +60,7 @@ jobs:
         with:
           python-version: ${{env.PYTHON_VERSION}}
       - name: Restore project Python cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           key: ${{env.PYTHON_CACHE_KEY}}
           path: ${{env.PYTHON_PATH}}
@@ -86,7 +86,7 @@ jobs:
         with:
           python-version: ${{env.PYTHON_VERSION}}
       - name: Restore project Python cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           key: ${{env.PYTHON_CACHE_KEY}}
           path: ${{env.PYTHON_PATH}}

--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -20,7 +20,7 @@ jobs:
           PYTHON_VERSION=$(jq --raw-output "._meta.requires.python_version" Pipfile.lock)
           echo "PYTHON_VERSION=${PYTHON_VERSION}" >> ${GITHUB_ENV}
       - name: Install project Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: ${{env.PYTHON_VERSION}}
       - name: Get project Python path
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v2.3.4
       - name: Install project Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: ${{env.PYTHON_VERSION}}
       - name: Restore project Python cache
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v2.3.4
       - name: Install project Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: ${{env.PYTHON_VERSION}}
       - name: Restore project Python cache

--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -14,7 +14,7 @@ jobs:
       PYTHON_PATH: ${{env.PYTHON_PATH}}
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Determine project Python version
         run: |
           PYTHON_VERSION=$(jq --raw-output "._meta.requires.python_version" Pipfile.lock)
@@ -54,7 +54,7 @@ jobs:
     steps:
       # The following three steps are (unfortunately) required to set up the job
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Install project Python
         uses: actions/setup-python@v2
         with:
@@ -80,7 +80,7 @@ jobs:
     steps:
       # The following three steps are (unfortunately) required to set up the job
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Install project Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Replaces the partial version numbers of all GitHub Action dependencies with the latest full equivalents. This includes:
- `actions/checkout`: `v2` ➡️  `v2.3.4`
- `actions/setup-python`: `v2` ➡️ `v2.1.4`
- `actions/cache`: `v2` ➡️ `v2.1.3`