### PR TITLE
Quality checking with Flake8

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ black = "==20.8b1"
 pytest = "*"
 coverage = "*"
 coveralls = "*"
+flake8 = "*"
 
 [packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2f0d4e8fe56bf0708b24869a053af1bde8f10af5fb7995399d7a8d7f1da6089c"
+            "sha256": "22631123124b65c44ef0bb146f4221a82bd5cb005335b6cee40dfaff7608de5b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -115,6 +115,14 @@
             ],
             "version": "==0.6.2"
         },
+        "flake8": {
+            "hashes": [
+                "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839",
+                "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"
+            ],
+            "index": "pypi",
+            "version": "==3.8.4"
+        },
         "idna": {
             "hashes": [
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
@@ -138,6 +146,13 @@
             ],
             "index": "pypi",
             "version": "==1.4.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
         },
         "mypy-extensions": {
             "hashes": [
@@ -176,6 +191,22 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.9.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.6.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.2.0"
         },
         "pyparsing": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,8 @@ omit = */__init__.py
 
 [coverage:report]
 fail_under = 90
+
+[flake8]
+max_line_length = 88
+extend_ignore = E203
+max_complexity = 10

--- a/tasks.py
+++ b/tasks.py
@@ -17,6 +17,14 @@ def check(context):
     print(" * black")
     print()
     failed = execute("black . --check")
+    print()
+    print(" * flake8")
+    print()
+    flake8_failed = execute("flake8 .")
+    # Upon flake8 success, print a message because flake8 doesn't do so on its own
+    if not flake8_failed:
+        print("No code quality issues found!")
+    failed = flake8_failed or failed
     sys.exit(failed)
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -14,7 +14,7 @@ UNSOLVED_GRID_STRING = """\
 ·   2   ·
          
 *   ·   ·\
-"""
+"""  # noqa: W293
 
 
 SOLVED_GRID_STRING = """\

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -8,7 +8,7 @@ GRID_STRING_1 = """\
 ·   2   ·
          
 *   ·   ·\
-"""
+"""  # noqa: W293
 
 GRID_STRING_2 = """\
 3---·---·

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -18,7 +18,7 @@ REVEAL_SEARCH_STRING = """\
 2---·
     |
 *   *
-"""
+"""  # noqa: W293
 
 
 def test_get_head_with_new_puzzle_returns_head():

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -8,7 +8,7 @@ UNSOLVED_GRID_STRING = """\
 ·   2   ·
          
 *   ·   ·\
-"""
+"""  # noqa: W293
 
 
 def test_direction_returns_valid_direction():


### PR DESCRIPTION
- Adds [Flake8](https://gitlab.com/pycqa/flake8) to the development dependencies.
- Includes Flake8 in the list of checks to run on invocation of the `check` task.
- Updates lines of code with necessary Flake8 violations (specifically, [W293](https://www.flake8rules.com/rules/W293.html) violations in multiline strings) to be ignored by Flake8.
- Configures Flake8 to be compatible with Black as per the instructions provided [here](https://github.com/psf/black/blob/20.8b1/docs/compatible_configs.md#flake8).
- Sets the McCabe complexity limit to 10 [in accordance with best practices](https://en.wikipedia.org/wiki/Cyclomatic_complexity#Limiting_complexity_during_development).

As of these changes, Flake8 will run as a part of the `check` task, which is most notably invoked by the Quality Control  workflow in response to new changes being pushed.