### PR TITLE
Refactor for isort

### DIFF
--- a/gaslines/display.py
+++ b/gaslines/display.py
@@ -1,6 +1,7 @@
-from gaslines.utility import get_number_of_rows
-from gaslines.solve import has_head
 import time
+
+from gaslines.solve import has_head
+from gaslines.utility import get_number_of_rows
 
 
 def reveal(strategy, delay):

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,6 @@
-import invoke
 import sys
+
+import invoke
 
 
 @invoke.task(name="format")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -3,6 +3,7 @@ import pytest
 from gaslines.display import Cursor, reveal
 from gaslines.grid import Grid
 
+
 # Note: these automated tests merely verify that the functions under test behave
 # consistently. Given the functions' visual nature, verification of correct behavior
 # initially required manual testing.

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,7 @@
-from gaslines.display import Cursor, reveal
-from gaslines.grid import Grid
 import pytest
 
+from gaslines.display import Cursor, reveal
+from gaslines.grid import Grid
 
 # Note: these automated tests merely verify that the functions under test behave
 # consistently. Given the functions' visual nature, verification of correct behavior

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,6 +1,6 @@
 import pytest
-from gaslines.grid import Grid
 
+from gaslines.grid import Grid
 
 GRID_STRING_1 = """\
 3   ·   ·

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -2,6 +2,7 @@ import pytest
 
 from gaslines.grid import Grid
 
+
 GRID_STRING_1 = """\
 3   ·   ·
          

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,6 +1,7 @@
 import pytest
-from gaslines.point import Point
+
 from gaslines.grid import Grid
+from gaslines.point import Point
 from gaslines.utility import Direction
 
 

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -1,7 +1,7 @@
-from gaslines.grid import Grid
-from gaslines.solve import get_head, has_head, is_option, get_next, Strategy, solve
 import pytest
 
+from gaslines.grid import Grid
+from gaslines.solve import Strategy, get_head, get_next, has_head, is_option, solve
 
 REVEAL_SEARCH_STRING = """\
 \x1b[J\

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -3,6 +3,7 @@ import pytest
 from gaslines.grid import Grid
 from gaslines.solve import Strategy, get_head, get_next, has_head, is_option, solve
 
+
 REVEAL_SEARCH_STRING = """\
 \x1b[J\
 2   ·

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,6 +1,6 @@
 import pytest
-from gaslines.utility import Direction, get_number_of_rows
 
+from gaslines.utility import Direction, get_number_of_rows
 
 UNSOLVED_GRID_STRING = """\
 3   ·   ·

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -2,6 +2,7 @@ import pytest
 
 from gaslines.utility import Direction, get_number_of_rows
 
+
 UNSOLVED_GRID_STRING = """\
 3   ·   ·
          


### PR DESCRIPTION
Includes some minor rearranging of imports in preparation for upcoming [isort](https://github.com/PyCQA/isort) import order enforcement.

I have verified locally that these are indeed the the only isort rule violations; their resolution puts this repository in full compliance with its forthcoming isort configuration.