### PR TITLE
Proxy approval GitHub workflow

### DIFF
--- a/.github/workflows/proxy-approval.yaml
+++ b/.github/workflows/proxy-approval.yaml
@@ -1,0 +1,22 @@
+# The following workflow runs upon the submission of a pull request review
+# If the review's summary comment is the same as this workflow's "TRIGGER_COMMENT",
+# the github-actions bot approves the pull request
+name: Proxy Approval
+on:
+  pull_request_review:
+    types: submitted
+jobs:
+  approve:
+    name: Approve
+    runs-on: ubuntu-18.04
+    timeout-minutes: 3
+    env:
+      # Defines the exact comment body that triggers an approval
+      TRIGGER_COMMENT: "@actions approve"
+    steps:
+      - name: Approve pull request
+        uses: hmarr/auto-approve-action@v2.0.0
+        # Approve the pull request only upon receiving the trigger comment
+        if: github.event.review.body == env.TRIGGER_COMMENT
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Adds a new GitHub Actions workflow, "Proxy Approval", which consists of a single job that runs whenever a new pull request review is submitted. This job checks the summary comment of that review and, in the case where the body of that comment matches the job's `TRIGGER_COMMENT` variable (hard-coded to be "@actions approve" at the time of writing this), the @actions bot approves the PR "on behalf of" the user that submitted the review.

In practice, this resolves #43 because this will allow me, the sole maintainer of this project, to avoid resorting to the use of administrator privileges to merge my own pull requests. The issue with using administrator privileges is that they override _all_ branch protection rules (a fact that led in part to issue #43), even though the only rule I consistently need to override is the requirement of at least one approving review. This change effectively allows me to approve my own pull requests, enabling me to override just the minimum approvals rule and still adhere to the others.

As a practical demonstration of this new functionality, I intend to self-approve this very PR. _Update: see demonstration [below](https://github.com/andrewtbiehl/gaslines/pull/45#pullrequestreview-538215518)._

Note: One might worry that this workflow poses a threat to the protected nature of the `main` branch. Fortunately this is, for the most part, not a concern. First, due to the nature of GitHub Actions tokens, the new workflow is only functional for internal [repository collaborators](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-your-github-user-account/permission-levels-for-a-user-account-repository#collaborator-access-for-a-repository-owned-by-a-user-account), so non-collaborators are still not able to merge to `main` without approval. And, while it is technically true that a rogue or absent-minded collaborator could indeed abuse this GitHub workflow to bypass peer-review, the fact that the workflow file was previously absent from the repository was not actually a safeguard against that, so nothing has changed in that respect either. My self-approval of this very PR is itself a demonstration of how a collaborator could use the github-actions bot to bypass peer-review in any situation. Despite this, I assume that any future collaborators would choose not to abuse this method based on the shared opinion that branch protection rules are always worth adhering to. The only thing to keep in mind, therefore, is that the owner should not add collaborators that do not share this opinion.