### PR TITLE
Refactor tasks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,9 @@ import sys
 import invoke
 
 
+ISORT_SUCCESS_MESSAGE = "No import order issues found!"
+
+
 @invoke.task(name="format")
 def format_(context):
     print("----FORMAT-----------------------")
@@ -15,7 +18,7 @@ def format_(context):
     isort_failed = execute("isort .")
     # Upon isort success, print a message because isort doesn't do so on its own
     if not isort_failed:
-        print("No import order issues found!")
+        print(ISORT_SUCCESS_MESSAGE)
     failed = isort_failed or failed
     sys.exit(failed)
 
@@ -40,7 +43,7 @@ def check(context):
     isort_failed = execute("isort . --check-only")
     # Upon isort success, print a message because isort doesn't do so on its own
     if not isort_failed:
-        print("No import order issues found!")
+        print(ISORT_SUCCESS_MESSAGE)
     failed = isort_failed or failed
     sys.exit(failed)
 

--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,15 @@ import sys
 import invoke
 
 
+# Simple shell script that replaces empty standard output with a custom message
+# Used as a wrapper for commands that print nothing upon success
+REPLACE_EMPTY_STDOUT_SCRIPT = """\
+output=$({command}); code=$?;
+if [ $code -eq 0 ] && [ -z "$output" ]; then output="{message}"; fi
+echo "$output" && exit $code
+"""
+
+
 ISORT_SUCCESS_MESSAGE = "No import order issues found!"
 
 
@@ -15,11 +24,11 @@ def format_(context):
     print()
     print(" * isort")
     print()
-    isort_failed = execute("isort .")
     # Upon isort success, print a message because isort doesn't do so on its own
-    if not isort_failed:
-        print(ISORT_SUCCESS_MESSAGE)
-    failed = isort_failed or failed
+    isort_command = REPLACE_EMPTY_STDOUT_SCRIPT.format(
+        command="isort .", message=ISORT_SUCCESS_MESSAGE
+    )
+    failed = execute(isort_command) or failed
     sys.exit(failed)
 
 
@@ -32,19 +41,19 @@ def check(context):
     print()
     print(" * flake8")
     print()
-    flake8_failed = execute("flake8 .")
     # Upon flake8 success, print a message because flake8 doesn't do so on its own
-    if not flake8_failed:
-        print("No code quality issues found!")
-    failed = flake8_failed or failed
+    flake8_command = REPLACE_EMPTY_STDOUT_SCRIPT.format(
+        command="flake8 .", message="No code quality issues found!"
+    )
+    failed = execute(flake8_command) or failed
     print()
     print(" * isort")
     print()
-    isort_failed = execute("isort . --check-only")
     # Upon isort success, print a message because isort doesn't do so on its own
-    if not isort_failed:
-        print(ISORT_SUCCESS_MESSAGE)
-    failed = isort_failed or failed
+    isort_command = REPLACE_EMPTY_STDOUT_SCRIPT.format(
+        command="isort . --check-only", message=ISORT_SUCCESS_MESSAGE
+    )
+    failed = execute(isort_command) or failed
     sys.exit(failed)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -55,25 +55,13 @@ CHECKS = OrderedDict(
 @invoke.task(name="format")
 def format_(context):
     print("----FORMAT-----------------------")
-    failed = False
-    for name, command in FORMATTERS.items():
-        print(f" * {name}")
-        print()
-        failed = execute(command) or failed
-        print()
-    sys.exit(failed)
+    execute_sequentially(FORMATTERS)
 
 
 @invoke.task
 def check(context):
     print("----CHECK------------------------")
-    failed = False
-    for name, command in CHECKS.items():
-        print(f" * {name}")
-        print()
-        failed = execute(command) or failed
-        print()
-    sys.exit(failed)
+    execute_sequentially(CHECKS)
 
 
 @invoke.task
@@ -96,6 +84,24 @@ def test(context, coverage=None):
         print()
         failed = execute("coveralls") or failed
     failed = execute("rm .coverage") or failed
+    sys.exit(failed)
+
+
+def execute_sequentially(commands):
+    """
+    Helper function that runs a sequence of provided shell commands, prints their
+    associated names simultaneously, and returns an error if any command failed.
+
+    Args:
+        commands (OrderedDict): Essentially a sequence of shell commands to execute.
+            The values are the actual commands and the keys are their names.
+    """
+    failed = False
+    for name, command in commands.items():
+        print(f" * {name}")
+        print()
+        failed = execute(command) or failed
+        print()
     sys.exit(failed)
 
 


### PR DESCRIPTION
Refactors `tasks.py` so that, for each of the `format` and `check` tasks, that task's tools are compiled into what is essentially a list (technically an `OrderedDict`), which is then run sequentially via a reusable helper function. 

With these improvements, adding a new tool to either of these tasks is as simple as appending that tool's shell command to that task's respective tool list. The tool lists for the `format` and `check` tasks are appropriately named `FORMATTERS` and `CHECKS`, respectively.