### PR TITLE
Module and function docstrings

### DIFF
--- a/gaslines/display.py
+++ b/gaslines/display.py
@@ -1,3 +1,9 @@
+"""
+Module that holds utilities specifically used to visualize Gas Lines puzzles and
+solutions in a standard terminal.
+"""
+
+
 import time
 
 from gaslines.solve import has_head

--- a/gaslines/grid.py
+++ b/gaslines/grid.py
@@ -23,10 +23,12 @@ class Grid:
 
     @property
     def height(self):
+        """Returns the height (i.e., number of rows) of the grid."""
         return self._height
 
     @property
     def length(self):
+        """Returns the length (i.e., number of columns) of the grid."""
         return self._length
 
     def __str__(self):

--- a/gaslines/grid.py
+++ b/gaslines/grid.py
@@ -1,3 +1,9 @@
+"""
+Container module for the gaslines Grid class, which holds grid-specific data for a Gas
+Lines puzzle.
+"""
+
+
 from gaslines.point import Point
 from gaslines.utility import Direction
 

--- a/gaslines/point.py
+++ b/gaslines/point.py
@@ -1,3 +1,9 @@
+"""
+Container module for the gaslines Point class, which holds all data specific to a
+single point on the grid of a Gas Lines puzzle.
+"""
+
+
 from gaslines.utility import Direction
 
 

--- a/gaslines/point.py
+++ b/gaslines/point.py
@@ -19,35 +19,51 @@ class Point:
 
     @property
     def grid(self):
+        """Returns the Grid object of which this point is a component."""
         return self._grid
 
     @property
     def location(self):
+        """
+        Returns an ordered pair comprising of the row- and column-index, respectively,
+        that determines this point's location in the grid.
+
+        The grid has a zero-based index with the origin in the top-right corner.
+        """
         return self._location
 
     @property
     def row_index(self):
+        """Returns the row index of the point in the grid."""
         return self.location[0]
 
     @property
     def column_index(self):
+        """Returns the column index of the point in the grid."""
         return self.location[1]
 
     def is_source(self):
+        """Returns whether the point is a 'source' point."""
         return self._type > 0
 
     def is_sink(self):
+        """Returns whether the point is a 'sink' point."""
         return self._type == Point.SINK
 
     @property
     def child(self):
+        """
+        Returns the child of this point, or None of this point currently has no child.
+        """
         return self._child
 
     @child.setter
     def child(self, point):
+        """Sets this point's child to the given point."""
         self._child = point
 
     def has_child(self):
+        """Returns whether this point has a child."""
         return self.child is not None
 
     def get_neighbor(self, direction):
@@ -63,6 +79,7 @@ class Point:
         return grid[i][j] if 0 <= i < grid.height and 0 <= j < grid.length else None
 
     def has_neighbor(self, direction):
+        """Returns whether this point has a neighbor in the given direction."""
         return self.get_neighbor(direction) is not None
 
     def get_neighbors(self):
@@ -108,6 +125,7 @@ class Point:
         return None
 
     def has_parent(self):
+        """Returns whether this point has a parent."""
         return self.parent is not None
 
     def is_open(self):

--- a/gaslines/solve.py
+++ b/gaslines/solve.py
@@ -153,4 +153,5 @@ def get_head(grid):
 
 
 def has_head(grid):
+    """Returns whether the given grid currently has a head."""
     return get_head(grid) is not None

--- a/gaslines/solve.py
+++ b/gaslines/solve.py
@@ -1,3 +1,9 @@
+"""
+Module that holds all utilities related to solving a Gas Lines puzzle. Most notably,
+this includes the various Gas Lines algorithms.
+"""
+
+
 import gaslines.display as display
 
 

--- a/gaslines/utility.py
+++ b/gaslines/utility.py
@@ -1,3 +1,9 @@
+"""
+Module that holds miscellaneous, general-purpose utilities used throughout the
+gaslines package.
+"""
+
+
 from enum import Enum
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,3 +1,9 @@
+"""
+Tasks module used by the Invoke task execution tool. Run `invoke --list` from the
+command line for more information on which tasks are available to run.
+"""
+
+
 import sys
 from collections import OrderedDict
 

--- a/tasks.py
+++ b/tasks.py
@@ -54,18 +54,41 @@ CHECKS = OrderedDict(
 
 @invoke.task(name="format")
 def format_(context):
+    """
+    Runs all formatting tools configured for use with this project.
+
+    Currently, this includes:
+    - black
+    - isort
+    """
     print("----FORMAT-----------------------")
     execute_sequentially(FORMATTERS)
 
 
 @invoke.task
 def check(context):
+    """
+    Runs all code checks configured for use with this project.
+
+    Currently, this includes:
+    - black
+    - flake8
+    - isort
+    """
     print("----CHECK------------------------")
     execute_sequentially(CHECKS)
 
 
 @invoke.task
 def test(context, coverage=None):
+    """
+    Runs tests and reports on the current the code coverage.
+
+    Args:
+        coverage (String): Optional argument for specifying what to do with the
+            coverage report. If "write", writes out the report in html form. If
+            "upload", uploads the report to coveralls. Otherwise, does nothing.
+    """
     print("----TEST-------------------------")
     # Run tests
     print(" * pytest")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,3 +1,6 @@
+"""All unit tests for the gaslines display module."""
+
+
 import pytest
 
 from gaslines.display import Cursor, reveal

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -29,22 +29,26 @@ SOLVED_GRID_STRING = """\
 
 @pytest.mark.parametrize("number_of_rows", (1, 2, 11, 101))
 def test_move_up_with_positive_number_prints_correct_code(capsys, number_of_rows):
+    """Verifies that `move_up` prints the expected terminal control code."""
     Cursor.move_up(number_of_rows)
     assert capsys.readouterr().out == f"\x1b[{number_of_rows}A"
 
 
 @pytest.mark.parametrize("number_of_rows", (0, -1, -2, -11, -101))
 def test_move_up_with_non_positive_number_does_nothing(capsys, number_of_rows):
+    """Verifies that `move_up` with a non-positive number prints nothing."""
     Cursor.move_up(number_of_rows)
     assert capsys.readouterr().out == ""
 
 
 def test_clear_below_prints_correct_code(capsys):
+    """Verifies that `clear_below` prints the expected terminal control code."""
     Cursor.clear_below()
     assert capsys.readouterr().out == "\x1b[J"
 
 
 def test_reveal_with_incomplete_puzzle_prints_and_backtracks(capsys):
+    """Verifies that `reveal` on an incomplete puzzle prints as expected."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Test reveal with mocked out strategy function and no delay
     reveal(strategy=lambda grid: None, delay=0)(grid)
@@ -52,6 +56,7 @@ def test_reveal_with_incomplete_puzzle_prints_and_backtracks(capsys):
 
 
 def test_reveal_with_complete_puzzle_prints_but_does_not_backtrack(capsys):
+    """Verifies that `reveal` on a complete puzzle prints as expected."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Set path from "3"
     grid[0][0].child = grid[0][1]

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -24,12 +24,14 @@ GRID_STRING_2 = """\
     "input_grid", (((-1,), (-1,)), ((1, 0), (-1, -1)), ((-1,), (-1,), (-1,)))
 )
 def test_dimensions_return_dimensions_when_asked(input_grid):
+    """Verifies that the height and length properties return the correct values."""
     output_grid = Grid(input_grid)
     assert output_grid.height == len(input_grid)
     assert output_grid.length == len(input_grid[0])
 
 
 def test_subscripting_returns_correct_points():
+    """Verifies that the subscript operator works as expected."""
     grid = Grid(
         (
             (-1, -1, -1),
@@ -55,11 +57,13 @@ def test_subscripting_returns_correct_points():
 
 
 def test_str_with_empty_board_returns_correct_string():
+    """Verifies that the string representation of an unsolved grid is correct."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert str(grid) == GRID_STRING_1
 
 
 def test_str_with_complete_board_returns_correct_string():
+    """Verifies that the string representation of a solved grid is correct."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Set path from "3"
     grid[0][0].child = grid[0][1]

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,3 +1,6 @@
+"""All unit tests for the gaslines grid module."""
+
+
 import pytest
 
 from gaslines.grid import Grid

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,3 +1,6 @@
+"""Trivial test module for verifying that unit tests are running as expected."""
+
+
 def test_health():
     """
     This health check test should pass no matter what.

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,3 +1,6 @@
+"""All unit tests for the gaslines point module."""
+
+
 import pytest
 
 from gaslines.grid import Grid

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -7,18 +7,21 @@ from gaslines.utility import Direction
 
 @pytest.mark.parametrize("grid", (None, [[0, 1], [None, None]], ((0, 1), (None, None))))
 def test_grid_returns_grid_when_asked(grid):
+    """Verifies that the grid property returns the expected grid."""
     point = Point(grid, None)
     assert point.grid == grid
 
 
 @pytest.mark.parametrize("location", (None, [0, 1], (0, 1)))
 def test_location_returns_location_when_asked(location):
+    """Verifies that the location property returns the expected location."""
     point = Point(None, location)
     assert point.location == location
 
 
 @pytest.mark.parametrize("row_index,column_index", ((0, 0), (0, 1), (1, 2)))
 def test_indexes_return_correct_values_when_asked(row_index, column_index):
+    """Verifies that the index properties return the expected indices."""
     point = Point(None, (row_index, column_index))
     assert point.row_index == row_index
     assert point.column_index == column_index
@@ -26,35 +29,41 @@ def test_indexes_return_correct_values_when_asked(row_index, column_index):
 
 @pytest.mark.parametrize("type_", (1, 2, 3, 9, 45))
 def test_is_source_returns_true_when_is_source(type_):
+    """Verifies that `is_source()` returns true for a source point."""
     point = Point(None, None, type_)
     assert point.is_source()
 
 
 @pytest.mark.parametrize("type_", (-1, 0, Point.PIPE, Point.SINK))
 def test_is_source_returns_false_when_is_not_source(type_):
+    """Verifies that `is_source()` returns false for a non-source point."""
     point = Point(None, None, type_)
     assert not point.is_source()
 
 
 @pytest.mark.parametrize("type_", (0, Point.SINK))
 def test_is_sink_returns_true_when_is_sink(type_):
+    """Verifies that `is_sink()` returns true for a sink point."""
     point = Point(None, None, type_)
     assert point.is_sink()
 
 
 @pytest.mark.parametrize("type_", (-1, 1, 2, 3, 9, 45, Point.PIPE))
 def test_is_sink_returns_false_when_is_not_sink(type_):
+    """Verifies that `is_sink()` returns false for a non-sink point."""
     point = Point(None, None, type_)
     assert not point.is_sink()
 
 
 def test_init_sets_pipe_when_no_type_provided():
+    """Verifies that the default init type is a pipe."""
     point = Point(None, None)
     assert not point.is_source()
     assert not point.is_sink()
 
 
 def test_child_returns_child_when_provided_child():
+    """Verifies that, with a child, the child property methods function correctly."""
     point = Point(None, None)
     child = Point(None, None)
     point.child = child
@@ -63,12 +72,14 @@ def test_child_returns_child_when_provided_child():
 
 
 def test_child_returns_no_child_when_not_provided_child():
+    """Verifies that, with no child, the child property methods function correctly."""
     point = Point(None, None)
     assert not point.has_child()
     assert point.child is None
 
 
 def test_child_returns_no_child_when_child_reset():
+    """Verifies that resetting a point's child works as expected."""
     point = Point(None, None)
     child = Point(None, None)
     # Test that child set correctly
@@ -82,6 +93,7 @@ def test_child_returns_no_child_when_child_reset():
 
 
 def test_get_neighbor_with_neighbor_present_returns_correct_point():
+    """Verifies that the neighbor method functions for a point with neighbors."""
     # The types have been carefully assigned for ease of testing
     grid = Grid(((0, 1, 0), (4, 5, 2), (0, 3, 0)))
     point = grid[1][1]
@@ -94,6 +106,7 @@ def test_get_neighbor_with_neighbor_present_returns_correct_point():
 
 
 def test_get_neighbor_with_missing_neighbor_returns_none():
+    """Verifies that the neighbor method functions for nonexistent neighbors."""
     # The types have been carefully assigned for ease of testing
     grid = Grid(((1, 2, 0), (0, 0, 3), (0, 0, 4)))
     # Test the north west point
@@ -123,6 +136,7 @@ def test_get_neighbor_with_missing_neighbor_returns_none():
 
 
 def test_get_neighbors_with_some_neighbors_returns_correct_points():
+    """Verifies that the neighbor method functions for points with some neighbors."""
     grid = Grid(((1, 2), (3, 0)))
     point = grid[0][0]
     assert point._type == 1
@@ -132,6 +146,7 @@ def test_get_neighbors_with_some_neighbors_returns_correct_points():
 
 
 def test_parent_with_parent_returns_correct_point():
+    """Verifies that parent property methods function for a point with a parent."""
     grid = Grid(((2, -1), (1, 0)))
     parent, child = grid[0][0], grid[0][1]
     parent.child = child
@@ -140,6 +155,7 @@ def test_parent_with_parent_returns_correct_point():
 
 
 def test_parent_with_no_parent_returns_none():
+    """Verifies that parent property methods function for a point without a parent."""
     grid = Grid(((2, -1), (1, 0)))
     point = grid[0][1]
     assert not point.has_parent()
@@ -147,6 +163,7 @@ def test_parent_with_no_parent_returns_none():
 
 
 def test_parent_with_sink_returns_none():
+    """Verifies that a sink point never reports that it has a parent."""
     grid = Grid(((2, -1), (1, 0)))
     source, pipe, sink = grid[0][0], grid[0][1], grid[1][1]
     source.child = pipe
@@ -156,11 +173,13 @@ def test_parent_with_sink_returns_none():
 
 
 def test_is_open_with_source_returns_false():
+    """Verifies that a source point never reports that it is open."""
     grid = Grid(((2, -1), (1, 0)))
     assert not grid[0][0].is_open()
 
 
 def test_is_open_with_sink_returns_true():
+    """Verifies that a sink point always reports that it is open."""
     grid = Grid(((2, -1), (1, 0)))
     sink = grid[1][1]
     # Test sink is open with no "parents"
@@ -175,6 +194,7 @@ def test_is_open_with_sink_returns_true():
 
 
 def test_is_open_with_pipe_conditional_on_parent():
+    """Verifies that a pipe reports being open if and only if it's parentless."""
     grid = Grid(((2, -1), (1, 0)))
     pipe = grid[0][1]
     # Test pipe without parent is open
@@ -185,6 +205,9 @@ def test_is_open_with_pipe_conditional_on_parent():
 
 
 def test_is_on_different_segment_with_source_returns_false():
+    """
+    Verifies that `is_on_different_segment` always reports false against sources.
+    """
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
     source = grid[0][0]
     assert not grid[0][1].is_on_different_segment(source)
@@ -192,24 +215,34 @@ def test_is_on_different_segment_with_source_returns_false():
 
 
 def test_is_on_different_segment_with_same_segment_returns_true():
+    """
+    Verifies that `is_on_different_segment` is true for a point on a new segment.
+    """
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
     grid[0][0].child = grid[0][1]
     assert grid[1][1].is_on_different_segment(grid[0][1])
 
 
 def test_is_on_different_segment_with_different_segment_returns_false():
+    """
+    Verifies that `is_on_different_segment` is false for a point on the same segment.
+    """
     grid = Grid(((2, -1, -1), (-1, -1, -1), (1, -1, 0)))
     grid[0][0].child = grid[0][1]
     assert not grid[0][2].is_on_different_segment(grid[0][1])
 
 
 def test_remaining_segments_with_source_returns_type():
+    """
+    Verifies that the number of remaining segments of a source point is what was set.
+    """
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert grid[0][0].remaining_segments == grid[0][0]._type == 3
     assert grid[1][1].remaining_segments == grid[1][1]._type == 2
 
 
 def test_remaining_segments_with_open_point_returns_none():
+    """Verifies that the number of remaining segments of an open point is None."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert grid[0][1].remaining_segments is None
     assert grid[1][0].remaining_segments is None
@@ -217,11 +250,15 @@ def test_remaining_segments_with_open_point_returns_none():
 
 
 def test_remaining_segments_with_sink_returns_none():
+    """Verifies that the number of remaining segments of a sink is None."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert grid[2][0].remaining_segments is None
 
 
 def test_remaining_segments_with_first_segment_returns_no_change():
+    """
+    Verifies that a source's child has an unchanged number of remaining segments.
+    """
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Test first point on first segment
     grid[0][0].child = grid[0][1]
@@ -232,6 +269,9 @@ def test_remaining_segments_with_first_segment_returns_no_change():
 
 
 def test_remaining_segments_with_new_segment_returns_change():
+    """
+    Verifies that moving to a new segment decrements the number of remaining segments.
+    """
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Test first point on second segment
     grid[0][0].child = grid[0][1]
@@ -247,12 +287,14 @@ def test_remaining_segments_with_new_segment_returns_change():
 
 
 def test_has_relationship_with_no_relationship_returns_false():
+    """Verifies that `has_relationship` returns false for two unrelated points."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     for direction in Direction:
         assert not grid[1][1].has_relationship(direction)
 
 
 def test_has_relationship_with_relationship_returns_true():
+    """Verifies that `has_relationship` returns true for related points."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Set path from "3"
     grid[0][0].child = grid[0][1]
@@ -280,6 +322,7 @@ def test_has_relationship_with_relationship_returns_true():
 
 
 def test_has_relationship_with_no_neighbor_returns_false():
+    """Verifies that `has_relationship` returns false against nonexistent points."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert not grid[0][0].has_relationship(Direction.NORTH)
     assert not grid[0][0].has_relationship(Direction.WEST)
@@ -287,23 +330,27 @@ def test_has_relationship_with_no_neighbor_returns_false():
 
 
 def test_str_with_source_returns_type():
+    """Verifies that the string value of a source point is its remaining segments."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert str(grid[0][0]) == "3"
     assert str(grid[1][1]) == "2"
 
 
 def test_str_with_pipe_returns_interpunct():
+    """Verifies that the string value of a pipe point is the interpunct character."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     for i, j in ((0, 1), (0, 2), (1, 2), (2, 1)):
         assert str(grid[i][j]) == chr(183) == "·"
 
 
 def test_str_with_sink_returns_asterisk():
+    """Verifies that the string value of a sink point is the asterisk character."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert str(grid[2][0]) == "*"
 
 
 def test_is_head_with_clean_puzzle_returns_sources():
+    """Verifies that the heads of a completely unsolved puzzle are its sources."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     sources_found = 0
     for row in grid:
@@ -317,6 +364,7 @@ def test_is_head_with_clean_puzzle_returns_sources():
 
 
 def test_is_head_with_head_pipe_returns_true():
+    """Verifies that `is_head()` returns true for pipes that are currently heads."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     grid[0][0].child = grid[0][1]
     assert not grid[0][0].is_head()
@@ -324,6 +372,7 @@ def test_is_head_with_head_pipe_returns_true():
 
 
 def test_is_head_with_sink_returns_false():
+    """Verifies that a sink never reports being a head."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Test sink with no parents
     assert not grid[2][0].is_head()
@@ -344,6 +393,7 @@ def test_is_head_with_sink_returns_false():
 
 
 def test_is_head_complete_puzzle_returns_no_heads():
+    """Verifies that a completely solved puzzle has no remaining heads."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Set path from "3"
     grid[0][0].child = grid[0][1]

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -23,12 +23,14 @@ REVEAL_SEARCH_STRING = """\
 
 
 def test_get_head_with_new_puzzle_returns_head():
+    """Verifies that `get_head` on a completely unsolved puzzle returns a head."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert has_head(grid)
     assert get_head(grid).location == (0, 0)
 
 
 def test_get_head_with_incomplete_puzzle_returns_head():
+    """Verifies that `get_head` on a partially solved puzzle returns a head."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Set partial path from "3"
     grid[0][0].child = grid[0][1]
@@ -43,6 +45,7 @@ def test_get_head_with_incomplete_puzzle_returns_head():
 
 
 def test_get_head_with_complete_puzzle_returns_none():
+    """Verifies that a completely solved puzzle reports having no heads."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Set path from "3"
     grid[0][0].child = grid[0][1]
@@ -59,6 +62,7 @@ def test_get_head_with_complete_puzzle_returns_none():
 
 
 def test_is_option_with_open_neighbor_returns_true():
+    """Verifies that `is_option` correctly identifies when a point is an option."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     current = grid[1][1]
     assert is_option(current, grid[0][1])
@@ -68,6 +72,9 @@ def test_is_option_with_open_neighbor_returns_true():
 
 
 def test_is_option_with_unavailable_neighbor_returns_false():
+    """
+    Verifies that `is_option` correctly identifies when a point is not an option.
+    """
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Set partial path from "3"
     grid[0][0].child = grid[0][1]
@@ -80,6 +87,7 @@ def test_is_option_with_unavailable_neighbor_returns_false():
 
 
 def test_is_option_with_same_segment_and_one_remaining_segment_returns_true():
+    """Verifies that a point on the last allowed segment is an option."""
     grid = Grid(((1, -1, -1, 0), (-1, -1, -1, -1)))
     current = grid[0][1]
     # Set partial path to current
@@ -88,6 +96,7 @@ def test_is_option_with_same_segment_and_one_remaining_segment_returns_true():
 
 
 def test_is_option_with_new_segment_and_one_remaining_segment_returns_false():
+    """Verifies that a point not on the last allowed segment is not an option."""
     grid = Grid(((1, -1, -1, 0), (-1, -1, -1, -1)))
     current = grid[0][1]
     # Set partial path to current
@@ -96,6 +105,7 @@ def test_is_option_with_new_segment_and_one_remaining_segment_returns_false():
 
 
 def test_is_option_with_same_segment_sink_and_one_remaining_segment_returns_true():
+    """Verifies that a sink on the last allowed segment is an option."""
     grid = Grid(((1, -1, 0), (-1, 0, -1)))
     current = grid[0][1]
     # Set partial path to current
@@ -104,6 +114,7 @@ def test_is_option_with_same_segment_sink_and_one_remaining_segment_returns_true
 
 
 def test_is_option_with_new_segment_sink_and_one_remaining_segment_returns_false():
+    """Verifies that a sink not on the last allowed segment is not an option."""
     grid = Grid(((1, -1, 0), (-1, 0, -1)))
     current = grid[0][1]
     # Set partial path to current
@@ -112,6 +123,7 @@ def test_is_option_with_new_segment_sink_and_one_remaining_segment_returns_false
 
 
 def test_is_option_with_same_segment_sink_and_two_remaining_segments_returns_false():
+    """Verifies that a sink on the second to last allowed segment is not an option."""
     grid = Grid(((2, -1, 0), (-1, 0, -1)))
     current = grid[0][1]
     # Set partial path to current
@@ -120,6 +132,7 @@ def test_is_option_with_same_segment_sink_and_two_remaining_segments_returns_fal
 
 
 def test_is_option_with_new_segment_sink_and_two_remaining_segments_returns_true():
+    """Verifies that a sink not on the second to last allowed segment is an option."""
     grid = Grid(((2, -1, 0), (-1, 0, -1)))
     current = grid[0][1]
     # Set partial path to current
@@ -128,6 +141,9 @@ def test_is_option_with_new_segment_sink_and_two_remaining_segments_returns_true
 
 
 def test_is_option_with_sink_and_greater_than_two_remaining_segments_returns_false():
+    """
+    Verifies that, with more than two remaining segments, a sink is not an option.
+    """
     grid = Grid(((-1, 0, -1), (3, -1, 0), (-1, -1, 0)))
     current = grid[1][1]
     # Set partial path to current
@@ -139,12 +155,18 @@ def test_is_option_with_sink_and_greater_than_two_remaining_segments_returns_fal
 
 
 def test_get_next_with_no_child_and_all_open_neighbors_returns_first_available():
+    """
+    Verifies that `get_next` returns the first available neighbor if all are open.
+    """
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert get_next(grid[0][0]).location == (0, 1)
     assert get_next(grid[1][1]).location == (0, 1)
 
 
 def test_get_next_with_no_child_and_some_open_neighbors_returns_first_available():
+    """
+    Verifies that `get_next` returns the first available neighbor if some are open.
+    """
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     # Set partial path from "3"
     grid[0][0].child = grid[0][1]
@@ -154,6 +176,7 @@ def test_get_next_with_no_child_and_some_open_neighbors_returns_first_available(
 
 
 def test_get_next_with_no_child_and_no_open_neighbors_returns_none():
+    """Verifies that `get_next` returns None if no neighbors are open."""
     grid = Grid(((4, -1, 1), (0, -1, -1), (-1, -1, 0)))
     # Set (incorrect) path from "4"
     grid[0][0].child = grid[0][1]
@@ -164,12 +187,18 @@ def test_get_next_with_no_child_and_no_open_neighbors_returns_none():
 
 
 def test_get_next_with_one_remaining_segment_skips_point_on_new_segment():
+    """
+    Verifies that `get_next`, on last allowed segment, skips points on new segments.
+    """
     grid = Grid(((-1, -1, -1, -1), (1, -1, -1, 0)))
     grid[1][0].child = grid[1][1]
     assert get_next(grid[1][1]).location == (1, 2)
 
 
 def test_get_next_with_two_remaining_segments_skips_sink_on_same_segment():
+    """
+    Verifies that `get_next` skips a sink not on the last allowed segment.
+    """
     grid = Grid(((2, -1, 0), (-1, 0, -1)))
     current = grid[0][1]
     # Set partial path to current
@@ -178,6 +207,9 @@ def test_get_next_with_two_remaining_segments_skips_sink_on_same_segment():
 
 
 def test_get_next_with_greater_than_two_remaining_segments_skips_sinks():
+    """
+    Verifies that `get_next` skips a sink not on the last allowed segment.
+    """
     grid = Grid(((-1, 0, -1), (4, -1, 0), (-1, -1, -1)))
     current = grid[1][1]
     # Set partial path to current
@@ -186,12 +218,18 @@ def test_get_next_with_greater_than_two_remaining_segments_skips_sinks():
 
 
 def test_get_next_with_first_of_multiple_children_returns_next_child():
+    """
+    Verifies that `get_next` on a point with a child returns the correct next point.
+    """
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     grid[1][1].child = grid[0][1]
     assert get_next(grid[1][1]).location == (1, 2)
 
 
 def test_get_next_with_last_child_returns_none():
+    """
+    Verifies that `get_next` on a point with its last possible child returns None.
+    """
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     grid[1][1].child = grid[1][0]
     assert get_next(grid[1][1]) is None
@@ -201,6 +239,7 @@ def test_get_next_with_last_child_returns_none():
     "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
 )
 def test_solve_with_trivial_example_solves_grid(strategy):
+    """Verifies that `solve` is able to solve a trivial Gas Lines puzzle."""
     grid = Grid(((1, 0),))
     assert solve(grid, strategy)
     assert grid[0][0].child.location == (0, 1)
@@ -210,6 +249,7 @@ def test_solve_with_trivial_example_solves_grid(strategy):
     "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
 )
 def test_solve_with_simple_example_solves_grid(strategy):
+    """Verifies that `solve` is able to solve a simple Gas Lines puzzle."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
     assert solve(grid, strategy)
     # Test all points in component-wise order
@@ -228,6 +268,7 @@ def test_solve_with_simple_example_solves_grid(strategy):
     "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
 )
 def test_solve_with_unsolvable_example_returns_false(strategy):
+    """Verifies that `solve` returns false for an unsolvable puzzle."""
     grid = Grid(((2, -1, -1), (-1, -1, -1), (-1, -1, -1)))
     assert not solve(grid, strategy)
     # Test that grid is clear
@@ -240,6 +281,7 @@ def test_solve_with_unsolvable_example_returns_false(strategy):
     "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
 )
 def test_solve_with_real_july_12_example_solves_grid(strategy):
+    """Verifies that `solve` is able to solve the July 12 Gas Lines puzzle."""
     # Real NYT Magazine Gas Lines puzzle from the July 12, 2020 issue
     grid = Grid(
         (
@@ -309,6 +351,7 @@ def test_solve_with_real_july_12_example_solves_grid(strategy):
     "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
 )
 def test_solve_with_real_august_9_example_solves_grid(strategy):
+    """Verifies that `solve` is able to solve the August 9 Gas Lines puzzle."""
     # Real NYT Magazine Gas Lines puzzle from the August 9, 2020 issue
     grid = Grid(
         (
@@ -378,6 +421,7 @@ def test_solve_with_real_august_9_example_solves_grid(strategy):
     "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
 )
 def test_solve_with_reveal_delay_activated_prints_accordingly(strategy, capsys):
+    """Verifies that `solve` using the reveal_delay option prints accordingly."""
     grid = Grid(((2, -1), (0, 0)))
     assert solve(grid, strategy, reveal_delay=0)
     assert capsys.readouterr().out == REVEAL_SEARCH_STRING

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -1,3 +1,6 @@
+"""All unit tests for the gaslines solve module."""
+
+
 import pytest
 
 from gaslines.grid import Grid

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -13,6 +13,7 @@ UNSOLVED_GRID_STRING = """\
 
 
 def test_direction_returns_valid_direction():
+    """Verifies that the Direction enum stores the correct direction vectors."""
     assert Direction.NORTH.value == (-1, 0)
     assert Direction.EAST.value == (0, 1)
     assert Direction.SOUTH.value == (1, 0)
@@ -20,6 +21,7 @@ def test_direction_returns_valid_direction():
 
 
 def test_list_returns_expected_direction_order():
+    """Verifies that listing the Direction elements returns the expected order."""
     assert list(Direction) == [
         Direction.NORTH,
         Direction.EAST,
@@ -35,4 +37,5 @@ def test_list_returns_expected_direction_order():
 def test_get_number_of_rows_with_input_string_returns_expected_number(
     input_string, expected_number
 ):
+    """Verifies that `get_number_of_rows` returns the expected number of rows."""
     assert get_number_of_rows(input_string) == expected_number

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,3 +1,6 @@
+"""All unit tests for the gaslines utility module."""
+
+
 import pytest
 
 from gaslines.utility import Direction, get_number_of_rows


### PR DESCRIPTION
Adds module docstrings and any previously missing function/method docstrings to all Python modules currently present in this repository.

This is done mainly in order to comply with conventions enforced by the [Pylint](https://github.com/PyCQA/pylint) code analysis tool, a tool which will soon be used programmatically in this repository. I'm still not 100% sure that I agree with the tool's suggestion to add docstrings to all unit tests, however I'd rather start from a place of compliance and then remove these docstrings later after further deliberation.