### PR TITLE
Patch Observable class

### DIFF
--- a/gaslines/utility.py
+++ b/gaslines/utility.py
@@ -44,13 +44,10 @@ class Observable:
     def __new__(cls, *_args, **_kwargs):
         # The args and kwargs may be used by __init__ but are not used here
         instance = super().__new__(cls)
-        # Explicitly initialize the new instance as an Observable
-        # This is done here so that a derived class won't have to do it itself
-        Observable.__init__(instance)
+        # Explicitly initialize the list of observers
+        # This is done here to prevent the need for explicit initialization elsewhere
+        instance._observers = []
         return instance
-
-    def __init__(self):
-        self._observers = []
 
     def register(self, observer):
         """

--- a/gaslines/utility.py
+++ b/gaslines/utility.py
@@ -41,7 +41,8 @@ class Observable:
     can use its functionality out-of-the-box by specifying it as a base class.
     """
 
-    def __new__(cls):
+    def __new__(cls, *_args, **_kwargs):
+        # The args and kwargs may be used by __init__ but are not used here
         instance = super().__new__(cls)
         # Explicitly initialize the new instance as an Observable
         # This is done here so that a derived class won't have to do it itself

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -56,6 +56,10 @@ class Switch:
 class MockDerivedObservable(Observable):
     """A mock class used to test inheritance of the Observable class."""
 
+    # Mock __init__ method used to verify that Observables may have attributes
+    def __init__(self, value):
+        self.value = value
+
     @Observable.observe
     def mock_observed_method(self):
         """A mock method used to test the `observe` decorator functionality."""
@@ -94,8 +98,8 @@ def test_get_number_of_rows_with_input_string_returns_expected_number(
     "observable,method",
     (
         (Observable(), Observable.notify),
-        (MockDerivedObservable(), MockDerivedObservable.notify),
-        (MockDerivedObservable(), MockDerivedObservable.mock_observed_method),
+        (MockDerivedObservable(None), MockDerivedObservable.notify),
+        (MockDerivedObservable(None), MockDerivedObservable.mock_observed_method),
     ),
 )
 def test_observable_method_with_observers_notifies_observers(observable, method):


### PR DESCRIPTION
Adds a couple of small patches to the `Observable` class in preparation for using it elsewhere in the project.
- Adds a patch to allow subclasses to have additional parameters in their `__init__` methods.
- Updates the initialization implementation to avoid any potential issues that might have arisen from unintended behavior where initializing the class directly results in its `__init__` method being called twice.

---

Note: in the messages of the commits to this branch I mistakenly referred to the `Observable` class as the 'Observer' class.