### PR TITLE
Branch coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [coverage:run]
+branch = True
 source = gaslines
 omit = */__init__.py
 


### PR DESCRIPTION
Updates the coverage settings to now include [branch coverage](https://coverage.readthedocs.io/en/v4.5.x/branch.html) in coverage checks.