### PR TITLE
Convert algorithms into functions

### DIFF
--- a/gaslines/logic.py
+++ b/gaslines/logic.py
@@ -1,79 +1,71 @@
 """
-Module that holds both the Strategy class, the container class for the various Gas
-Lines algorithms, and helper functions for said algorithms.
+Module that holds the algorithms for solving Gas Lines puzzles as well as helper
+functions for those algorithms.
+
+It is recommended to call the algorithms indirectly via the solve function.
 """
 
 
-class Strategy:
+def full_recursive(grid, current=None):
     """
-    Container class for algorithms that solve Gas Lines puzzles.
+    A depth-first, fully recursive approach to solving Gas Lines puzzles.
 
-    It is recommended to call these strategies indirectly via the solve function.
+    Mutates the grid object provided to search for a solution and returns True
+    once a solution has been found or False if no solution exists.
+
+    Retains a placeholder of its current position in order to be fully recursive.
+
+    Args:
+        grid (Grid): A partially solved Gas Lines grid.
+        current (Point): A point in the grid from which to begin recursion. Should
+            not be explicitly set with the initial call of the algorithm.
+
+    Returns:
+        bool: Whether the grid can be (or is) solved in its current state.
     """
-
-    @staticmethod
-    def full_recursive(grid, current=None):
-        """
-        A depth-first, fully recursive approach to solving Gas Lines puzzles.
-
-        Mutates the grid object provided to search for a solution and returns True
-        once a solution has been found or False if no solution exists.
-
-        Retains a placeholder of its current position in order to be fully recursive.
-
-        Args:
-            grid (Grid): A partially solved Gas Lines grid.
-            current (Point): A point in the grid from which to begin recursion. Should
-                not be explicitly set with the initial call of the algorithm.
-
-        Returns:
-            bool: Whether the grid can be (or is) solved in its current state.
-        """
-        if current is None or current.is_sink():
-            # Base case: a grid with no remaining heads is already in a solved state
-            if not has_head(grid):
-                return True
-            current = get_head(grid)
-        # Reset the child of "current" with the next candidate
-        next_ = get_next(current)
-        current.child = next_
-        if next_ is None:
-            return False
-        # Recursive case: continue search starting at the child of "current" and then,
-        # if no solution is found, search again starting at "current" with new child
-        return Strategy.full_recursive(grid, next_) or Strategy.full_recursive(
-            grid, current
-        )
-
-    @staticmethod
-    def partial_recursive(grid):
-        """
-        A depth-first, partially recursive approach to solving Gas Lines puzzles.
-
-        Mutates the grid object provided to search for a solution and returns True
-        once a solution has been found or False if no solution exists.
-
-        Recursive calls retain no memory of previous states, so the algorithm has to
-        explicitly iterate through all recursive searches from the current state.
-
-        Args:
-            grid (Grid): A partially solved Gas Lines grid.
-
-        Returns:
-            bool: Whether the grid can be (or is) solved in its current state.
-        """
+    if current is None or current.is_sink():
         # Base case: a grid with no remaining heads is already in a solved state
         if not has_head(grid):
             return True
         current = get_head(grid)
-        # Iterate through each possible next point from "current"
-        while (next_ := get_next(current)) is not None:
-            current.child = next_
-            # Recursive case: continue searching with a new child of "current"
-            if Strategy.partial_recursive(grid):
-                return True
-        current.child = None
+    # Reset the child of "current" with the next candidate
+    next_ = get_next(current)
+    current.child = next_
+    if next_ is None:
         return False
+    # Recursive case: continue search starting at the child of "current" and then,
+    # if no solution is found, search again starting at "current" with new child
+    return full_recursive(grid, next_) or full_recursive(grid, current)
+
+
+def partial_recursive(grid):
+    """
+    A depth-first, partially recursive approach to solving Gas Lines puzzles.
+
+    Mutates the grid object provided to search for a solution and returns True
+    once a solution has been found or False if no solution exists.
+
+    Recursive calls retain no memory of previous states, so the algorithm has to
+    explicitly iterate through all recursive searches from the current state.
+
+    Args:
+        grid (Grid): A partially solved Gas Lines grid.
+
+    Returns:
+        bool: Whether the grid can be (or is) solved in its current state.
+    """
+    # Base case: a grid with no remaining heads is already in a solved state
+    if not has_head(grid):
+        return True
+    current = get_head(grid)
+    # Iterate through each possible next point from "current"
+    while (next_ := get_next(current)) is not None:
+        current.child = next_
+        # Recursive case: continue searching with a new child of "current"
+        if partial_recursive(grid):
+            return True
+    current.child = None
+    return False
 
 
 def get_next(current):

--- a/gaslines/logic.py
+++ b/gaslines/logic.py
@@ -11,10 +11,8 @@ class Strategy:
     It is recommended to call these strategies indirectly via the solve function.
     """
 
-    # Note: These algorithms are implemented as instance methods in order to allow
-    # the solve function to temporarily decorate them with additional features
-
-    def full_recursive(self, grid, current=None):
+    @staticmethod
+    def full_recursive(grid, current=None):
         """
         A depth-first, fully recursive approach to solving Gas Lines puzzles.
 
@@ -43,9 +41,12 @@ class Strategy:
             return False
         # Recursive case: continue search starting at the child of "current" and then,
         # if no solution is found, search again starting at "current" with new child
-        return self.full_recursive(grid, next_) or self.full_recursive(grid, current)
+        return Strategy.full_recursive(grid, next_) or Strategy.full_recursive(
+            grid, current
+        )
 
-    def partial_recursive(self, grid):
+    @staticmethod
+    def partial_recursive(grid):
         """
         A depth-first, partially recursive approach to solving Gas Lines puzzles.
 
@@ -69,7 +70,7 @@ class Strategy:
         while (next_ := get_next(current)) is not None:
             current.child = next_
             # Recursive case: continue searching with a new child of "current"
-            if self.partial_recursive(grid):
+            if Strategy.partial_recursive(grid):
                 return True
         current.child = None
         return False

--- a/gaslines/solve.py
+++ b/gaslines/solve.py
@@ -29,14 +29,11 @@ def solve(grid, strategy=Strategy.full_recursive, reveal_delay=None):
     Returns:
         bool: Whether the grid has a solution.
     """
-    strategy_name = strategy.__name__
-    strategy_container = Strategy()
-    solve = getattr(strategy_container, strategy_name)
-    # Optionally decorate the algorithm with reveal functionality
+    # Optionally reveal the grid while it is being solved
     if reveal_delay is not None:
         # Reveal the grid once after each mutation
         reveal = functools.partial(display.reveal, grid, reveal_delay)
         grid.register(reveal)
         # Also reveal the grid in its initial state, prior to solving it
         reveal()
-    return solve(grid)
+    return strategy(grid)

--- a/gaslines/solve.py
+++ b/gaslines/solve.py
@@ -8,10 +8,10 @@ Lines puzzle.
 import functools
 
 import gaslines.display as display
-from gaslines.logic import Strategy
+from gaslines.logic import full_recursive
 
 
-def solve(grid, strategy=Strategy.full_recursive, reveal_delay=None):
+def solve(grid, strategy=full_recursive, reveal_delay=None):
     """
     Solves a Gas Lines puzzle (using the strategy provided).
 
@@ -20,8 +20,8 @@ def solve(grid, strategy=Strategy.full_recursive, reveal_delay=None):
 
     Args:
         grid (Grid): A (presumably unsolved) Gas Lines grid.
-        strategy (Strategy class method): The choice of algorithm with which to solve
-            the grid. Defaults to the "full_recursive" strategy.
+        strategy (function): The choice of algorithm with which to solve the grid.
+            Defaults to the "full_recursive" strategy.
         reveal_delay (float, NoneType): If not None, displays intermediate stages of
             the search, pausing between each stage for the given number of seconds.
             Defaults to None.

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -4,7 +4,7 @@
 import pytest
 
 from gaslines.grid import Grid
-from gaslines.logic import Strategy
+from gaslines.logic import full_recursive, partial_recursive
 from gaslines.solve import solve
 
 
@@ -26,9 +26,7 @@ REVEAL_SEARCH_STRING = """\
 """  # noqa: W293
 
 
-@pytest.mark.parametrize(
-    "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
-)
+@pytest.mark.parametrize("strategy", (full_recursive, partial_recursive))
 def test_solve_with_trivial_example_solves_grid(strategy):
     """Verifies that `solve` is able to solve a trivial Gas Lines puzzle."""
     grid = Grid(((1, 0),))
@@ -36,9 +34,7 @@ def test_solve_with_trivial_example_solves_grid(strategy):
     assert grid[0][0].child.location == (0, 1)
 
 
-@pytest.mark.parametrize(
-    "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
-)
+@pytest.mark.parametrize("strategy", (full_recursive, partial_recursive))
 def test_solve_with_simple_example_solves_grid(strategy):
     """Verifies that `solve` is able to solve a simple Gas Lines puzzle."""
     grid = Grid(((3, -1, -1), (-1, 2, -1), (0, -1, -1)))
@@ -55,9 +51,7 @@ def test_solve_with_simple_example_solves_grid(strategy):
     assert grid[2][2].child.location == (2, 1)
 
 
-@pytest.mark.parametrize(
-    "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
-)
+@pytest.mark.parametrize("strategy", (full_recursive, partial_recursive))
 def test_solve_with_unsolvable_example_returns_false(strategy):
     """Verifies that `solve` returns false for an unsolvable puzzle."""
     grid = Grid(((2, -1, -1), (-1, -1, -1), (-1, -1, -1)))
@@ -68,9 +62,7 @@ def test_solve_with_unsolvable_example_returns_false(strategy):
             assert point.is_source() or point.is_open()
 
 
-@pytest.mark.parametrize(
-    "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
-)
+@pytest.mark.parametrize("strategy", (full_recursive, partial_recursive))
 def test_solve_with_real_july_12_example_solves_grid(strategy):
     """Verifies that `solve` is able to solve the July 12 Gas Lines puzzle."""
     # Real NYT Magazine Gas Lines puzzle from the July 12, 2020 issue
@@ -138,9 +130,7 @@ def test_solve_with_real_july_12_example_solves_grid(strategy):
     assert grid[6][6].is_open()
 
 
-@pytest.mark.parametrize(
-    "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
-)
+@pytest.mark.parametrize("strategy", (full_recursive, partial_recursive))
 def test_solve_with_real_august_9_example_solves_grid(strategy):
     """Verifies that `solve` is able to solve the August 9 Gas Lines puzzle."""
     # Real NYT Magazine Gas Lines puzzle from the August 9, 2020 issue
@@ -208,9 +198,7 @@ def test_solve_with_real_august_9_example_solves_grid(strategy):
     assert grid[6][6].child.location == (6, 5)
 
 
-@pytest.mark.parametrize(
-    "strategy", (Strategy.full_recursive, Strategy.partial_recursive)
-)
+@pytest.mark.parametrize("strategy", (full_recursive, partial_recursive))
 def test_solve_with_reveal_delay_activated_prints_accordingly(strategy, capsys):
     """Verifies that `solve` using the reveal_delay option prints accordingly."""
     grid = Grid(((2, -1), (0, 0)))


### PR DESCRIPTION
Converts both algorithms into stand-alone functions, and removes the consequently unnecessary `Strategy` class that contained them . Also simplifies the `solve` function so that these algorithms are called directly, and updates all affected tests and docstrings accordingly.