### PR TITLE
Contextless Invoke tasks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -181,7 +181,7 @@ def task(_function=None, *args, use_context=True, **kwargs):  # pylint: disable=
     return task_decorator if _function is None else task_decorator(_function)
 
 
-@invoke.task(name="format")
+@task(name="format")
 def format_(context):  # pylint: disable=W0613
     """
     Runs all formatting tools configured for use with this project.
@@ -194,7 +194,7 @@ def format_(context):  # pylint: disable=W0613
     execute_sequentially(FORMATTERS)
 
 
-@invoke.task
+@task
 def check(context):  # pylint: disable=W0613
     """
     Runs all code checks configured for use with this project.
@@ -208,7 +208,7 @@ def check(context):  # pylint: disable=W0613
     execute_sequentially(CHECKS)
 
 
-@invoke.task
+@task
 def test(context, coverage=None):  # pylint: disable=W0613
     """
     Runs tests and reports on the current the code coverage.

--- a/tasks.py
+++ b/tasks.py
@@ -181,8 +181,8 @@ def task(_function=None, *args, use_context=True, **kwargs):  # pylint: disable=
     return task_decorator if _function is None else task_decorator(_function)
 
 
-@task(name="format")
-def format_(context):  # pylint: disable=W0613
+@task(use_context=False, name="format")
+def format_():
     """
     Runs all formatting tools configured for use with this project.
 
@@ -194,8 +194,8 @@ def format_(context):  # pylint: disable=W0613
     execute_sequentially(FORMATTERS)
 
 
-@task
-def check(context):  # pylint: disable=W0613
+@task(use_context=False)
+def check():
     """
     Runs all code checks configured for use with this project.
 
@@ -208,8 +208,8 @@ def check(context):  # pylint: disable=W0613
     execute_sequentially(CHECKS)
 
 
-@task
-def test(context, coverage=None):  # pylint: disable=W0613
+@task(use_context=False)
+def test(coverage=None):
     """
     Runs tests and reports on the current the code coverage.
 

--- a/tasks.py
+++ b/tasks.py
@@ -65,6 +65,21 @@ CHECKS = OrderedDict(
 )
 
 
+def compose(outer_function, inner_function):
+    """
+    Utility function that returns the composition of two functions.
+
+    Args:
+        outer_function (function): A function that can take as input the output of
+            `inner_function`.
+        inner_function (function): Any function.
+
+    Returns:
+        function: The composition of `outer_function` with `inner_function`.
+    """
+    return lambda *args, **kwargs: outer_function(inner_function(*args, **kwargs))
+
+
 @invoke.task(name="format")
 def format_(context):  # pylint: disable=W0613
     """


### PR DESCRIPTION
Adds to (and makes use of in) the `tasks` module a new `task` utility function (and some helper functions). This `task` function allows for the creation of an Invoke task without the requirement that the decorated function must have an initial context parameter.

Eventually, this functionality may be provided directly by Invoke, at which point this code may be replaced by the Invoke equivalent. See pyinvoke/invoke#445 and pyinvoke/invoke#473 for more information.