### PR TITLE
Dynamic tool list descriptions for format and check tasks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -189,6 +189,20 @@ def task(_function=None, *args, use_context=True, **kwargs):  # pylint: disable=
     return task_decorator if _function is None else task_decorator(_function)
 
 
+def create_bulleted_list(items, bullet="-"):
+    """
+    Returns a text-based bulleted list of the given items.
+
+    Args:
+        items (iterable): The items to add to the text-based list.
+        bullet (str): The choice of bullet to use. Defaults to "-".
+
+    Returns:
+        str: A bulleted, newline delimited list of the given items.
+    """
+    return "\n".join(f"{bullet} {item}" for item in items)
+
+
 @task(use_context=False, name="format")
 def format_():
     """

--- a/tasks.py
+++ b/tasks.py
@@ -30,6 +30,9 @@ LINTER_SUCCESS_MESSAGE = "No code quality issues found!"
 TOOL_LIST_HEADER = "Currently, this includes:" + "\n"
 
 
+PARAGRAPH_SEPARATOR = "\n" * 2
+
+
 # A list of formatter tools to run
 # The keys are the tool names and the values are the shell commands
 FORMATTERS = collections.OrderedDict(
@@ -236,6 +239,20 @@ def create_bulleted_tool_list(tools):
         str: A bulleted list of tool names.
     """
     return TOOL_LIST_HEADER + create_bulleted_list(tools.keys())
+
+
+def append_tool_list_to_docstring(tools):
+    """
+    Helper function that appends a list of the given tools to the docstring of the
+    annotated task function.
+
+    Args:
+        tools (OrderedDict): The tools to add as a bulleted list to the docstring.
+
+    Returns:
+        function: A standard function decorator.
+    """
+    return append_to_docstring(PARAGRAPH_SEPARATOR + create_bulleted_tool_list(tools))
 
 
 @task(use_context=False, name="format")

--- a/tasks.py
+++ b/tasks.py
@@ -27,6 +27,9 @@ ISORT_SUCCESS_MESSAGE = "No import order issues found!"
 LINTER_SUCCESS_MESSAGE = "No code quality issues found!"
 
 
+TOOL_LIST_HEADER = "Currently, this includes:" + "\n"
+
+
 # A list of formatter tools to run
 # The keys are the tool names and the values are the shell commands
 FORMATTERS = collections.OrderedDict(
@@ -219,6 +222,20 @@ def append_to_docstring(content):
         return function
 
     return wrapper
+
+
+def create_bulleted_tool_list(tools):
+    """
+    Helper function that returns a text-based bulleted list of the given tools.
+
+    Args:
+        tools (OrderedDict): The tools whose names (the keys) will be added to the
+            text-based list.
+
+    Returns:
+        str: A bulleted list of tool names.
+    """
+    return TOOL_LIST_HEADER + create_bulleted_list(tools.keys())
 
 
 @task(use_context=False, name="format")

--- a/tasks.py
+++ b/tasks.py
@@ -256,29 +256,20 @@ def append_tool_list_to_docstring(tools):
 
 
 @task(use_context=False, name="format")
+@append_tool_list_to_docstring(FORMATTERS)
 def format_():
     """
     Runs all formatting tools configured for use with this project.
-
-    Currently, this includes:
-    - black
-    - isort
     """
     print("----FORMAT-----------------------")
     execute_sequentially(FORMATTERS)
 
 
 @task(use_context=False)
+@append_tool_list_to_docstring(CHECKS)
 def check():
     """
     Runs all code checks configured for use with this project.
-
-    Currently, this includes:
-    - black
-    - flake8
-    - isort
-    - pylint
-    - yamllint
     """
     print("----CHECK------------------------")
     execute_sequentially(CHECKS)

--- a/tasks.py
+++ b/tasks.py
@@ -203,6 +203,24 @@ def create_bulleted_list(items, bullet="-"):
     return "\n".join(f"{bullet} {item}" for item in items)
 
 
+def append_to_docstring(content):
+    """
+    Appends the given content to the docstring of the decorated function.
+
+    Args:
+        content (str): The text to append to the decorated function's docstring.
+
+    Returns:
+        function: A standard function decorator.
+    """
+
+    def wrapper(function):
+        function.__doc__ += content
+        return function
+
+    return wrapper
+
+
 @task(use_context=False, name="format")
 def format_():
     """

--- a/tasks.py
+++ b/tasks.py
@@ -258,9 +258,7 @@ def append_tool_list_to_docstring(tools):
 @task(use_context=False, name="format")
 @append_tool_list_to_docstring(FORMATTERS)
 def format_():
-    """
-    Runs all formatting tools configured for use with this project.
-    """
+    """Runs all formatting tools configured for use with this project."""
     print("----FORMAT-----------------------")
     execute_sequentially(FORMATTERS)
 
@@ -268,9 +266,7 @@ def format_():
 @task(use_context=False)
 @append_tool_list_to_docstring(CHECKS)
 def check():
-    """
-    Runs all code checks configured for use with this project.
-    """
+    """Runs all code checks configured for use with this project."""
     print("----CHECK------------------------")
     execute_sequentially(CHECKS)
 


### PR DESCRIPTION
Replaces the hard-coded tool list descriptions in the docstrings of both the `format` and `check` tasks with dynamic, automatically generated lists. 

Previously, each time an additional tool was added to either task, the docstring for that task would have to be updated manually. Being rather minor, this change was often forgotten, which resulted in outdated documentation (see PRs #80, #86, and #87, for example). These changes resolve that issue by making this documentation dynamically generate based on the actual tool list run by each task. In other words, it will no longer be necessary to remember to update this particular documentation because it now stays up-to-date automatically.