### PR TITLE
Add flake8-bugbear to Flake8 plugins

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ flake8 = "*"
 isort = "*"
 pylint = "*"
 yamllint = "*"
+flake8-bugbear = "*"
 
 [packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ccb43e629bfe31909c1f8013cd8a8030584d17822fded414b3f6523570e2694e"
+            "sha256": "0602fda9eaaa73ab8c24fb48ef36203181cac56c19e2c01ba887787ba99961a3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -145,6 +145,14 @@
             ],
             "index": "pypi",
             "version": "==3.9.1"
+        },
+        "flake8-bugbear": {
+            "hashes": [
+                "sha256:2346c81f889955b39e4a368eb7d508de723d9de05716c287dc860a4073dc57e7",
+                "sha256:4f305dca96be62bf732a218fe6f1825472a621d3452c5b994d8f89dae21dbafa"
+            ],
+            "index": "pypi",
+            "version": "==21.4.3"
         },
         "idna": {
             "hashes": [


### PR DESCRIPTION
Adds [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) as a development dependency, which in turn automatically includes it among the list of plugins run by Flake8.

The project is already fully compliant with flake8-bugbear, so no code changes were required in order to include the plugin.

This happens to be the first external Flake8 plugin added to this project.
