### PR TITLE
Add flake8-commas to Flake8 plugins

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ isort = "*"
 pylint = "*"
 yamllint = "*"
 flake8-bugbear = "*"
+flake8-commas = "*"
 
 [packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0602fda9eaaa73ab8c24fb48ef36203181cac56c19e2c01ba887787ba99961a3"
+            "sha256": "19f97a0b4d7575db10c9a6469d0657aa59528718331884ba6fd86f0e58c7b32c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -153,6 +153,14 @@
             ],
             "index": "pypi",
             "version": "==21.4.3"
+        },
+        "flake8-commas": {
+            "hashes": [
+                "sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7",
+                "sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
         },
         "idna": {
             "hashes": [

--- a/tasks.py
+++ b/tasks.py
@@ -41,10 +41,11 @@ FORMATTERS = collections.OrderedDict(
         (
             "isort",
             REPLACE_EMPTY_STDOUT_SCRIPT.format(
-                command="isort .", message=ISORT_SUCCESS_MESSAGE
+                command="isort .",
+                message=ISORT_SUCCESS_MESSAGE,
             ),
         ),
-    )
+    ),
 )
 
 
@@ -56,28 +57,32 @@ CHECKS = collections.OrderedDict(
         (
             "flake8",
             REPLACE_EMPTY_STDOUT_SCRIPT.format(
-                command="flake8 .", message=LINTER_SUCCESS_MESSAGE
+                command="flake8 .",
+                message=LINTER_SUCCESS_MESSAGE,
             ),
         ),
         (
             "isort",
             REPLACE_EMPTY_STDOUT_SCRIPT.format(
-                command="isort . --check-only", message=ISORT_SUCCESS_MESSAGE
+                command="isort . --check-only",
+                message=ISORT_SUCCESS_MESSAGE,
             ),
         ),
         (
             "pylint",
             REPLACE_EMPTY_STDOUT_SCRIPT.format(
-                command="pylint tasks.py gaslines tests", message=LINTER_SUCCESS_MESSAGE
+                command="pylint tasks.py gaslines tests",
+                message=LINTER_SUCCESS_MESSAGE,
             ),
         ),
         (
             "yamllint",
             REPLACE_EMPTY_STDOUT_SCRIPT.format(
-                command="yamllint --format=colored .", message=LINTER_SUCCESS_MESSAGE
+                command="yamllint --format=colored .",
+                message=LINTER_SUCCESS_MESSAGE,
             ),
         ),
-    )
+    ),
 )
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -44,7 +44,8 @@ class Incrementor:
 
 
 @pytest.mark.parametrize(
-    "input_grid", (((-1,), (-1,)), ((1, 0), (-1, -1)), ((-1,), (-1,), (-1,)))
+    "input_grid",
+    (((-1,), (-1,)), ((1, 0), (-1, -1)), ((-1,), (-1,), (-1,))),
 )
 def test_dimensions_return_dimensions_when_asked(input_grid):
     """Verifies that the height and length properties return the correct values."""

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -45,7 +45,7 @@ def july_12_grid():
             (-1, -1, -1, -1, -1, 0, -1),
             (-1, -1, 0, -1, -1, -1, -1),
             (5, -1, -1, 2, -1, -1, -1),
-        )
+        ),
     )
 
 
@@ -77,7 +77,7 @@ def august_9_grid():
             (-1, -1, -1, -1, -1, -1, -1),
             (-1, 3, 0, -1, -1, 4, -1),
             (4, -1, -1, -1, -1, -1, -1),
-        )
+        ),
     )
 
 
@@ -344,7 +344,8 @@ def zip_points_and_children(grid, child_locations):
 
     # Flatten both provided collections at the same time for brevity
     points, child_locations = map(
-        itertools.chain.from_iterable, (grid, child_locations)
+        itertools.chain.from_iterable,
+        (grid, child_locations),
     )
     # Use the previously defined closure to construct a list of child points
     children = map(get_nullable_point, child_locations)
@@ -362,7 +363,9 @@ def zip_points_and_children(grid, child_locations):
     ),
 )
 def test_algorithm_with_solvable_example_solves_grid(
-    strategy, grid, expected_child_locations
+    strategy,
+    grid,
+    expected_child_locations,
 ):
     """Verifies that each algorithm is able to solve each provided puzzle."""
     # Call the `grid` and `expected_child_locations` creators during each test
@@ -373,6 +376,7 @@ def test_algorithm_with_solvable_example_solves_grid(
     # Verify each actual child against the expected child one by one
     # Note that the child of a sink point should be `None`
     for point, expected_child in zip_points_and_children(
-        grid, expected_child_locations
+        grid,
+        expected_child_locations,
     ):
         assert point.child is expected_child

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -88,7 +88,8 @@ def test_list_returns_expected_direction_order():
     (("", 1), ("a", 1), ("\n", 2), ("a\nb\nc", 3), (UNSOLVED_GRID_STRING, 5)),
 )
 def test_get_number_of_rows_with_input_string_returns_expected_number(
-    input_string, expected_number
+    input_string,
+    expected_number,
 ):
     """Verifies that `get_number_of_rows` returns the expected number of rows."""
     assert get_number_of_rows(input_string) == expected_number


### PR DESCRIPTION
Adds [flake8-commas](https://github.com/PyCQA/flake8-commas) as a development dependency, which in turn automatically includes it among the list of plugins run by Flake8. Also adds trailing commas in various places in order to comply with this new linter.