### PR TITLE
Remove commented-out code with eradicate

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ flake8-bugbear = "*"
 flake8-commas = "*"
 vulture = "*"
 eradicate = "*"
+ydiff = "*"
 
 [packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ yamllint = "*"
 flake8-bugbear = "*"
 flake8-commas = "*"
 vulture = "*"
+eradicate = "*"
 
 [packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9a6f35cb9f39b4b3a0e55d27f72db05fc6ecaa3531d1fba4186fe569e2968c7c"
+            "sha256": "6468899262bbf11ef0789ef4442eab1cc3149a79da262a3cc11410f4842bf2c0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -428,6 +428,13 @@
             ],
             "index": "pypi",
             "version": "==1.26.1"
+        },
+        "ydiff": {
+            "hashes": [
+                "sha256:f5430577ecd30974d766ee9b8333e06dc76a947b4aae36d39612a0787865a121"
+            ],
+            "index": "pypi",
+            "version": "==1.2"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9a972c0a7ec1bb1bc8c358bb323156bb695b76eb3a570583fdd6be88940eac60"
+            "sha256": "9a6f35cb9f39b4b3a0e55d27f72db05fc6ecaa3531d1fba4186fe569e2968c7c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -138,6 +138,13 @@
                 "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
             ],
             "version": "==0.6.2"
+        },
+        "eradicate": {
+            "hashes": [
+                "sha256:27434596f2c5314cc9b31410c93d8f7e8885747399773cd088d3adea647a60c8"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
         },
         "flake8": {
             "hashes": [

--- a/tasks.py
+++ b/tasks.py
@@ -69,6 +69,10 @@ PARAGRAPH_SEPARATOR = "\n" * 2
 # The keys are the tool names and the values are the shell commands
 FORMATTERS = collections.OrderedDict(
     (
+        (
+            "eradicate",
+            ERADICATE_FORMAT_SCRIPT,
+        ),
         ("black", "black ."),
         (
             "isort",
@@ -120,6 +124,10 @@ CHECKS = collections.OrderedDict(
                 command="vulture",
                 message=LINTER_SUCCESS_MESSAGE,
             ),
+        ),
+        (
+            "eradicate",
+            ERADICATE_CHECK_SCRIPT,
         ),
     ),
 )

--- a/tasks.py
+++ b/tasks.py
@@ -21,6 +21,38 @@ echo "$output" && exit $code
 """
 
 
+# Shell script that combines eradicate with ydiff to enable prettier diff printing
+# Intended for use by the format task
+ERADICATE_FORMAT_SCRIPT = """\
+success="All files left unchanged!"
+error="The following changes were made:"
+disclaimer="Disclaimer: this tool is imperfect; further changes may be required."
+output=$(eradicate --recursive --aggressive . | ydiff --pager=cat --color=always);
+if [ -z "$output" ]; then
+  echo "$success";
+else
+  eradicate --recursive --aggressive --in-place .;
+  echo "$error\n\n$output\n\n$disclaimer";
+fi
+"""
+
+
+# Shell script that combines eradicate with ydiff to enable prettier diff printing
+# Intended for use by the check task
+ERADICATE_CHECK_SCRIPT = """\
+success="No commented-out code found!"
+error="The following changes would be made:"
+output=$(eradicate --recursive --aggressive --error .); code=$?;
+if [ $code -eq 0 ]; then
+  output="$success"
+else
+  output=$(echo "$output" | ydiff --pager=cat --color=always);
+  output="$error\n\n$output";
+fi
+echo "$output" && exit $code
+"""
+
+
 ISORT_SUCCESS_MESSAGE = "No import order issues found!"
 
 


### PR DESCRIPTION
- Adds both [eradicate](https://github.com/myint/eradicate) and [ydiff](https://github.com/ymattw/ydiff) to the development dependencies.
- Adds two eradicate scripts to the tasks module, one for finding and another for removing commented-out code. These scripts combine eradicate with ydiff to enable prettier printing of the diff output produced by eradicate.
- Includes the aforementioned scripts in the list of checks run in the `check` task and the list of formatters run in the `format` task, respectively.

As of these changes, eradicate will run as a part of both the `format` and `check` tasks, the latter of which, most notably, is invoked by the Quality Control GitHub workflow in response to new changes being pushed.
