### PR TITLE
Check for bad prose with proselint

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ flake8-commas = "*"
 vulture = "*"
 eradicate = "*"
 ydiff = "*"
+proselint = "*"
 
 [packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6468899262bbf11ef0789ef4442eab1cc3149a79da262a3cc11410f4842bf2c0"
+            "sha256": "d5ded37a3effb5ebe05803a6525dd3655b96f3d94c69dbb8ed4772caf729e328"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -62,10 +62,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:7d8c289ee437bcb0316820ccee14aefcb056e58d31830ecab8e47eda6540e136",
-                "sha256:e90e62ced43dc8105fb9a26d62f0d9340b5c8db053a814e25d95c19873ae87db"
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
             ],
-            "version": "==8.0.0"
+            "version": "==8.0.1"
         },
         "coverage": {
             "hashes": [
@@ -127,11 +127,11 @@
         },
         "coveralls": {
             "hashes": [
-                "sha256:7bd173b3425733661ba3063c88f180127cc2b20e9740686f86d2622b31b41385",
-                "sha256:cbb942ae5ef3d2b55388cb5b43e93a269544911535f1e750e1c656aef019ce60"
+                "sha256:172fb79c5f61c6ede60554f2cac46deff6d64ee735991fb2124fb414e188bdb4",
+                "sha256:9b3236e086627340bf2c95f89f757d093cbed43d17179d3f4fb568c347e7d29a"
             ],
             "index": "pypi",
-            "version": "==3.0.1"
+            "version": "==3.1.0"
         },
         "docopt": {
             "hashes": [
@@ -169,6 +169,12 @@
             ],
             "index": "pypi",
             "version": "==2.0.0"
+        },
+        "future": {
+            "hashes": [
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+            ],
+            "version": "==0.18.2"
         },
         "idna": {
             "hashes": [
@@ -262,6 +268,14 @@
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
             "version": "==0.13.1"
+        },
+        "proselint": {
+            "hashes": [
+                "sha256:3a87eb393056d1bc77d898e4bcf8998f50e9ad84f7b9ff7cf2720509ac8ef904",
+                "sha256:7db295005d1a2c597ab44b359fea95bb6b92e739784aede69f8ba7098b3c3244"
+            ],
+            "index": "pypi",
+            "version": "==0.10.2"
         },
         "py": {
             "hashes": [
@@ -393,6 +407,13 @@
                 "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
             "version": "==2.25.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "version": "==1.16.0"
         },
         "toml": {
             "hashes": [

--- a/tasks.py
+++ b/tasks.py
@@ -165,6 +165,10 @@ CHECKS = collections.OrderedDict(
             "eradicate",
             ERADICATE_CHECK_SCRIPT,
         ),
+        (
+            "proselint",
+            PROSELINT_CHECK_SCRIPT,
+        ),
     ),
 )
 

--- a/tasks.py
+++ b/tasks.py
@@ -21,6 +21,42 @@ echo "$output" && exit $code
 """
 
 
+PROSELINT_IGNORED_PATHS_REGEX = "^({paths})".format(
+    paths="|".join(
+        (
+            r"\./\.git/",
+            r"\./\.pytest_cache/",
+        ),
+    ),
+)
+
+
+PROSELINT_IGNORED_ERRORS_REGEX = "({errors})".format(
+    errors="|".join(
+        (
+            r"typography\.symbols\.copyright",
+            r"typography\.symbols\.curly_quotes",
+            r"\./\.yamllint\.yaml:18:14: garner\.phrasal_adjectives\.ly",
+        ),
+    ),
+)
+
+
+# Shell script that runs proselint on a filtered list of files and then filters out
+# false positive errors
+PROSELINT_CHECK_SCRIPT = """\
+checked_files=$(find . -type f | grep --extended-regexp --invert-match "{p_regex}");
+raw_output=$(echo "$checked_files" | xargs proselint);
+output=$(echo "$raw_output" | grep --extended-regexp --invert-match "{e_regex}");
+code=$(expr 1 - $?);
+if [ $code -eq 0 ]; then output="No prose issues found!"; fi
+echo "$output" && exit $code;
+""".format(
+    p_regex=PROSELINT_IGNORED_PATHS_REGEX,
+    e_regex=PROSELINT_IGNORED_ERRORS_REGEX,
+)
+
+
 # Shell script that combines eradicate with ydiff to enable prettier diff printing
 # Intended for use by the format task
 ERADICATE_FORMAT_SCRIPT = """\


### PR DESCRIPTION
- Adds [proselint](https://github.com/amperser/proselint) to the development dependencies.
- Adds a script to the tasks module that runs proselint on a filtered list of files and then filters out its false positive errors.
- Includes the aforementioned script in the list of checks run in the `check` task.

As of these changes, proselint will run as a part of the `check` task, which, most notably, is invoked by the Quality Control GitHub workflow in response to new changes being pushed.
