### PR TITLE
Rename constant

### DIFF
--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -6,7 +6,7 @@ import pytest
 from gaslines.utility import Direction, Observable, get_number_of_rows
 
 
-UNSOLVED_GRID_STRING = """\
+GRID_STRING = """\
 3   ·   ·
          
 ·   2   ·
@@ -85,7 +85,7 @@ def test_list_returns_expected_direction_order():
 
 @pytest.mark.parametrize(
     "input_string,expected_number",
-    (("", 1), ("a", 1), ("\n", 2), ("a\nb\nc", 3), (UNSOLVED_GRID_STRING, 5)),
+    (("", 1), ("a", 1), ("\n", 2), ("a\nb\nc", 3), (GRID_STRING, 5)),
 )
 def test_get_number_of_rows_with_input_string_returns_expected_number(
     input_string,


### PR DESCRIPTION
Renames the `UNSOLVED_GRID_STRING` constant in the utility tests module to just `GRID_STRING`.