### PR TITLE
Specify GitHub Settings as code

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,66 @@
+repository:
+  name: gaslines
+  description: >-
+    A simple library for solving and generating instances of the NYT Magazine Gas Lines
+    Puzzle
+  topics: python, fun, puzzle
+  homepage: null
+  default_branch: main
+  private: false
+  is_template: false
+  has_wiki: false
+  has_issues: true
+  has_projects: false
+  has_pages: false
+  has_downloads: false
+  allow_merge_commit: true
+  allow_squash_merge: true
+  allow_rebase_merge: false
+  delete_branch_on_merge: true
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      required_status_checks:
+        strict: true
+        contexts: [Setup, Check, Test, coverage/coveralls]
+      required_signatures: true
+      required_linear_history: true
+      enforce_admins: true
+      allow_force_pushes: false
+      allow_deletions: false
+      restrictions: null
+labels:
+  - name: bug
+    color: "#d73a4a"
+    description: Something isn't working
+  - name: dependencies
+    color: "#0e8a16"
+    description: Version bump of a dependency
+  - name: documentation
+    color: "#0075ca"
+    description: Improvements or additions to documentation
+  - name: duplicate
+    color: "#cfd3d7"
+    description: This issue or pull request already exists
+  - name: enhancement
+    color: "#a2eeef"
+    description: New feature or request
+  - name: good first issue
+    color: "#7057ff"
+    description: Good for newcomers
+  - name: help wanted
+    color: "#008672"
+    description: Extra attention is needed
+  - name: invalid
+    color: "#e4e669"
+    description: This doesn't seem right
+  - name: question
+    color: "#d876e3"
+    description: Further information is requested
+  - name: wontfix
+    color: "#ffffff"
+    description: This will not be worked on


### PR DESCRIPTION
Enables the specification of GitHub repository settings as code by adding the `.github/settings.yml` configuration file for the [GitHub Settings Probot app](https://github.com/probot/settings), preconfigured to match the current GitHub settings of this repository.

The GitHub Settings app has already been installed for this repository. Because of this, as of these changes, the Settings app will now ensure that the GitHub settings for this repository are up to date with the specifications of this configuration file any time that changes are merged into the trunk (i.e. `main`)  branch. Of course, in practice, most times the configuration file itself will not be included among the files changed, in which case no changes to this repository's GitHub settings will occur.

Also note that, since the configuration file has been preconfigured to match the current GitHub settings of this repository, these particular changes being merged into the trunk branch will also not effect any changes to this repository's actual GitHub settings.
