### PR TITLE
Require conversation resolution for PRs into main

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -27,6 +27,7 @@ branches:
       required_status_checks:
         strict: true
         contexts: [Setup, Check, Test, coverage/coveralls]
+      required_conversation_resolution: true
       required_signatures: true
       required_linear_history: true
       enforce_admins: true


### PR DESCRIPTION
Enables the requirement of conversation resolution in order to merge any PR into the trunk (i.e. `main`) branch.

The official GitHub documentation for this setting can be found [here](https://docs.github.com/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-conversation-resolution-before-merging).