### PR TITLE
Define GitHub workflow permissions

### DIFF
--- a/.github/workflows/proxy-approval.yaml
+++ b/.github/workflows/proxy-approval.yaml
@@ -2,6 +2,8 @@
 # If the review's summary comment is the same as this workflow's "TRIGGER_COMMENT",
 # the github-actions bot approves the pull request
 name: Proxy Approval
+permissions:
+  pull-requests: write
 "on":
   pull_request_review:
     types: submitted

--- a/.github/workflows/quality-control.yaml
+++ b/.github/workflows/quality-control.yaml
@@ -1,6 +1,7 @@
 # The following workflow runs upon pushing new commits to any branches
 # It runs and reports all code quality checks required to merge to main
 name: Quality Control
+permissions: {}
 "on": push
 jobs:
   # The following job is for any setup that can be outsourced from the other jobs


### PR DESCRIPTION
Explicitly sets the permissions for both of the existing GitHub workflows in accordance with the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege).

See the [official documentation on GitHub workflow permissions](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) for more information.