### PR TITLE
Generalize eradicate scripts

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -57,20 +57,25 @@ echo "$output" && exit $code;
 )
 
 
+ERADICATE_CHECK_COMMAND = "eradicate . --recursive --aggressive"
+
+
 # Shell script that combines eradicate with ydiff to enable prettier diff printing
 # Intended for use by the format task
 ERADICATE_FORMAT_SCRIPT = """\
 success="All files left unchanged!"
 error="The following changes were made:"
 disclaimer="Disclaimer: this tool is imperfect; further changes may be required."
-output=$(eradicate . --recursive --aggressive | ydiff --pager=cat --color=always);
+output=$({base_command} | ydiff --pager=cat --color=always);
 if [ -z "$output" ]; then
   echo "$success";
 else
-  eradicate . --recursive --aggressive --in-place;
+  {base_command} --in-place;
   echo "$error\n\n$output\n\n$disclaimer";
 fi
-"""
+""".format(
+    base_command=ERADICATE_CHECK_COMMAND,
+)
 
 
 # Shell script that combines eradicate with ydiff to enable prettier diff printing
@@ -78,7 +83,7 @@ fi
 ERADICATE_CHECK_SCRIPT = """\
 success="No commented-out code found!"
 error="The following changes would be made:"
-output=$(eradicate . --recursive --aggressive); code=1 && [ -z "$output" ] && code=0;
+output=$({command}); code=1 && [ -z "$output" ] && code=0;
 if [ $code -eq 0 ]; then
   output="$success"
 else
@@ -86,7 +91,9 @@ else
   output="$error\n\n$output";
 fi
 echo "$output" && exit $code
-"""
+""".format(
+    command=ERADICATE_CHECK_COMMAND,
+)
 
 
 ISORT_SUCCESS_MESSAGE = "No import order issues found!"

--- a/tasks.py
+++ b/tasks.py
@@ -57,12 +57,6 @@ echo "$output" && exit $code;
 )
 
 
-ERADICATE_CHECK_COMMAND = "eradicate . --recursive --aggressive"
-
-
-ERADICATE_SUCCESS_MESSAGE = "No commented-out code found!"
-
-
 # Shell script pipes output from a command to ydiff to enable prettier diff printing
 # The command must support the `--in-place` flag for modifying files
 # Intended for use by the format task
@@ -94,6 +88,12 @@ else
 fi
 echo "$output" && exit $code
 """
+
+
+ERADICATE_CHECK_COMMAND = "eradicate . --recursive --aggressive"
+
+
+ERADICATE_SUCCESS_MESSAGE = "No commented-out code found!"
 
 
 ISORT_SUCCESS_MESSAGE = "No import order issues found!"

--- a/tasks.py
+++ b/tasks.py
@@ -78,7 +78,7 @@ fi
 ERADICATE_CHECK_SCRIPT = """\
 success="No commented-out code found!"
 error="The following changes would be made:"
-output=$(eradicate . --recursive --aggressive --error); code=$?;
+output=$(eradicate . --recursive --aggressive); code=1 && [ -z "$output" ] && code=0;
 if [ $code -eq 0 ]; then
   output="$success"
 else

--- a/tasks.py
+++ b/tasks.py
@@ -60,6 +60,9 @@ echo "$output" && exit $code;
 ERADICATE_CHECK_COMMAND = "eradicate . --recursive --aggressive"
 
 
+ERADICATE_SUCCESS_MESSAGE = "No commented-out code found!"
+
+
 # Shell script that combines eradicate with ydiff to enable prettier diff printing
 # Intended for use by the format task
 ERADICATE_FORMAT_SCRIPT = """\
@@ -81,7 +84,7 @@ fi
 # Shell script that combines eradicate with ydiff to enable prettier diff printing
 # Intended for use by the check task
 ERADICATE_CHECK_SCRIPT = """\
-success="No commented-out code found!"
+success="{message}"
 error="The following changes would be made:"
 output=$({command}); code=1 && [ -z "$output" ] && code=0;
 if [ $code -eq 0 ]; then
@@ -93,6 +96,7 @@ fi
 echo "$output" && exit $code
 """.format(
     command=ERADICATE_CHECK_COMMAND,
+    message=ERADICATE_SUCCESS_MESSAGE,
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -63,11 +63,11 @@ ERADICATE_FORMAT_SCRIPT = """\
 success="All files left unchanged!"
 error="The following changes were made:"
 disclaimer="Disclaimer: this tool is imperfect; further changes may be required."
-output=$(eradicate --recursive --aggressive . | ydiff --pager=cat --color=always);
+output=$(eradicate . --recursive --aggressive | ydiff --pager=cat --color=always);
 if [ -z "$output" ]; then
   echo "$success";
 else
-  eradicate --recursive --aggressive --in-place .;
+  eradicate . --recursive --aggressive --in-place;
   echo "$error\n\n$output\n\n$disclaimer";
 fi
 """
@@ -78,7 +78,7 @@ fi
 ERADICATE_CHECK_SCRIPT = """\
 success="No commented-out code found!"
 error="The following changes would be made:"
-output=$(eradicate --recursive --aggressive --error .); code=$?;
+output=$(eradicate . --recursive --aggressive --error); code=$?;
 if [ $code -eq 0 ]; then
   output="$success"
 else

--- a/tasks.py
+++ b/tasks.py
@@ -63,9 +63,10 @@ ERADICATE_CHECK_COMMAND = "eradicate . --recursive --aggressive"
 ERADICATE_SUCCESS_MESSAGE = "No commented-out code found!"
 
 
-# Shell script that combines eradicate with ydiff to enable prettier diff printing
+# Shell script pipes output from a command to ydiff to enable prettier diff printing
+# The command must support the `--in-place` flag for modifying files
 # Intended for use by the format task
-ERADICATE_FORMAT_SCRIPT = """\
+FORMAT_AND_PRETTY_PRINT_DIFF_SCRIPT = """\
 success="All files left unchanged!"
 error="The following changes were made:"
 disclaimer="Disclaimer: this tool is imperfect; further changes may be required."
@@ -76,14 +77,12 @@ else
   {base_command} --in-place;
   echo "$error\n\n$output\n\n$disclaimer";
 fi
-""".format(
-    base_command=ERADICATE_CHECK_COMMAND,
-)
+"""
 
 
-# Shell script that combines eradicate with ydiff to enable prettier diff printing
+# Shell script pipes output from a command to ydiff to enable prettier diff printing
 # Intended for use by the check task
-ERADICATE_CHECK_SCRIPT = """\
+CHECK_AND_PRETTY_PRINT_DIFF_SCRIPT = """\
 success="{message}"
 error="The following changes would be made:"
 output=$({command}); code=1 && [ -z "$output" ] && code=0;
@@ -94,10 +93,7 @@ else
   output="$error\n\n$output";
 fi
 echo "$output" && exit $code
-""".format(
-    command=ERADICATE_CHECK_COMMAND,
-    message=ERADICATE_SUCCESS_MESSAGE,
-)
+"""
 
 
 ISORT_SUCCESS_MESSAGE = "No import order issues found!"
@@ -118,7 +114,9 @@ FORMATTERS = collections.OrderedDict(
     (
         (
             "eradicate",
-            ERADICATE_FORMAT_SCRIPT,
+            FORMAT_AND_PRETTY_PRINT_DIFF_SCRIPT.format(
+                base_command=ERADICATE_CHECK_COMMAND,
+            ),
         ),
         ("black", "black ."),
         (
@@ -174,7 +172,10 @@ CHECKS = collections.OrderedDict(
         ),
         (
             "eradicate",
-            ERADICATE_CHECK_SCRIPT,
+            CHECK_AND_PRETTY_PRINT_DIFF_SCRIPT.format(
+                command=ERADICATE_CHECK_COMMAND,
+                message=ERADICATE_SUCCESS_MESSAGE,
+            ),
         ),
         (
             "proselint",


### PR DESCRIPTION
Converts two scripts originally intended solely for the tool 'eradicate' into more generic scripts that could (and in fact will) be used with other tools.

These changes directly anticipate the addition of the tool '[autoflake](https://github.com/myint/autoflake)' to the existing set of formatters/checkers enforced in this project.
