### PR TITLE
Remove unused code with autoflake

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ eradicate = "*"
 ydiff = "*"
 proselint = "*"
 flake8-comprehensions = "*"
+autoflake = "*"
 
 [packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,10 +26,10 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:3c9a2d84354185d13213ff2640ec03d39168dbcd13648abc84fb13ca3b2e2761",
-                "sha256:d66a600e1602736a0f24f725a511b0e50d12eb18f54b31ec276d2c26a0a62c6a"
+                "sha256:4db03ab5fc3340cf619dbc25e42c2cc3755154ce6009469766d7143d1fc2ee4e",
+                "sha256:8a398dfce302c13f14bab13e2b14fe385d32b73f4e4853b9bdfb64598baa1975"
             ],
-            "version": "==2.5.7"
+            "version": "==2.5.6"
         },
         "attrs": {
             "hashes": [
@@ -48,10 +48,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
-                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
             ],
-            "version": "==2020.12.5"
+            "version": "==2021.5.30"
         },
         "chardet": {
             "hashes": [
@@ -308,11 +308,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:586d8fa9b1891f4b725f587ef267abe2a1bad89d6b184520c7f07a253dd6e217",
-                "sha256:f7e2072654a6b6afdf5e2fb38147d3e2d2d43c89f648637baab63e026481279b"
+                "sha256:0a049c5d47b629d9070c3932d13bff482b12119b6a241a93bc460b0be16953c8",
+                "sha256:792b38ff30903884e4a9eab814ee3523731abd3c463f3ba48d7b627e87013484"
             ],
             "index": "pypi",
-            "version": "==2.8.2"
+            "version": "==2.8.3"
         },
         "pyparsing": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e83b9da8ded7858ae42338695418addf598c17775b779af550f98d5f8c8faadc"
+            "sha256": "e7d6e2bca0802187674e8d76b87f5a8450c684cd54ad507d4ae71e8babced6ba"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,6 +37,13 @@
                 "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
             "version": "==21.2.0"
+        },
+        "autoflake": {
+            "hashes": [
+                "sha256:61a353012cff6ab94ca062823d1fb2f692c4acda51c76ff83a8d77915fba51ea"
+            ],
+            "index": "pypi",
+            "version": "==1.4"
         },
         "black": {
             "hashes": [

--- a/tasks.py
+++ b/tasks.py
@@ -93,7 +93,23 @@ echo "$output" && exit $code
 ERADICATE_CHECK_COMMAND = "eradicate . --recursive --aggressive"
 
 
+AUTOFLAKE_CHECK_COMMAND = " ".join(
+    (
+        "autoflake",
+        ".",
+        "--expand-star-imports",
+        "--remove-all-unused-imports",
+        "--remove-duplicate-keys",
+        "--remove-unused-variables",
+        "--recursive",
+    ),
+)
+
+
 ERADICATE_SUCCESS_MESSAGE = "No commented-out code found!"
+
+
+AUTOFLAKE_SUCCESS_MESSAGE = "No unused code found!"
 
 
 ISORT_SUCCESS_MESSAGE = "No import order issues found!"
@@ -116,6 +132,12 @@ FORMATTERS = collections.OrderedDict(
             "eradicate",
             FORMAT_AND_PRETTY_PRINT_DIFF_SCRIPT.format(
                 base_command=ERADICATE_CHECK_COMMAND,
+            ),
+        ),
+        (
+            "autoflake",
+            FORMAT_AND_PRETTY_PRINT_DIFF_SCRIPT.format(
+                base_command=AUTOFLAKE_CHECK_COMMAND,
             ),
         ),
         ("black", "black ."),

--- a/tasks.py
+++ b/tasks.py
@@ -203,6 +203,13 @@ CHECKS = collections.OrderedDict(
             "proselint",
             PROSELINT_CHECK_SCRIPT,
         ),
+        (
+            "autoflake",
+            CHECK_AND_PRETTY_PRINT_DIFF_SCRIPT.format(
+                command=AUTOFLAKE_CHECK_COMMAND,
+                message=AUTOFLAKE_SUCCESS_MESSAGE,
+            ),
+        ),
     ),
 )
 


### PR DESCRIPTION
- Adds [autoflake](https://github.com/myint/autoflake) to the development dependencies.
- Includes autoflake in both the list of formatters and the list of checks to run on invocation of the `format` and `check` tasks, respectively.
- Brings all dependencies specified in the lockfile (i.e. `Pipfile.lock`) up to date.

As of these changes, autoflake will run as a part of both the `format` and `check` tasks, the latter of which most notably is invoked by the Quality Control  GitHub workflow in response to new changes being pushed.