### PR TITLE
Add flake8-pytest-style to Flake8 plugins

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ proselint = "*"
 flake8-comprehensions = "*"
 autoflake = "*"
 pybetter = "*"
+flake8-pytest-style = "*"
 
 [packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9316d2358ae12e6ff7ca0c7077174dbc0bb21861e511bace3cfbeccbe1b6f9bd"
+            "sha256": "f25769e9c3a93b23eeb4ac137adfdd4f5d57e474e2edcc6c593a8a9bedc9d267"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -184,6 +184,21 @@
             ],
             "index": "pypi",
             "version": "==3.5.0"
+        },
+        "flake8-plugin-utils": {
+            "hashes": [
+                "sha256:1fe43e3e9acf3a7c0f6b88f5338cad37044d2f156c43cb6b080b5f9da8a76f06",
+                "sha256:20fa2a8ca2decac50116edb42e6af0a1253ef639ad79941249b840531889c65a"
+            ],
+            "version": "==1.3.2"
+        },
+        "flake8-pytest-style": {
+            "hashes": [
+                "sha256:33a2f24c65a5cbd68c501459a5c49b81f4a5e506e3e53afef968942f8e45a2f9",
+                "sha256:c2d11f3964928a8bf8d160c66b28a3c92209f4cde286338adac9ccdf9a3fcbb3"
+            ],
+            "index": "pypi",
+            "version": "==1.4.2"
         },
         "future": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -476,11 +476,11 @@
         },
         "typing-inspect": {
             "hashes": [
-                "sha256:3b98390df4d999a28cf5b35d8b333425af5da2ece8a4ea9e98f71e7591347b4f",
-                "sha256:8f1b1dd25908dbfd81d3bebc218011531e7ab614ba6e5bf7826d887c834afab7",
-                "sha256:de08f50a22955ddec353876df7b2545994d6df08a2f45d54ac8c05e530372ca0"
+                "sha256:047d4097d9b17f46531bf6f014356111a1b6fb821a24fe7ac909853ca2a782aa",
+                "sha256:3cd7d4563e997719a710a3bfe7ffb544c6b72069b6812a02e9b414a8fa3aaa6b",
+                "sha256:b1f56c0783ef0f25fb064a01be6e5407e54cf4a4bf4f3ba3fe51e0bd6dcea9e5"
             ],
-            "version": "==0.6.0"
+            "version": "==0.7.1"
         },
         "urllib3": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ fail_under = 90
 max_line_length = 88
 extend_ignore = E203
 max_complexity = 10
+pytest_parametrize_values_type = tuple
 
 [isort]
 profile = black

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -65,7 +65,8 @@ def test_subscripting_returns_correct_points():
         assert grid[3]
     # Test that the first row only has pipes
     for point in grid[0]:
-        assert not point.is_source() and not point.is_sink()
+        assert not point.is_source()
+        assert not point.is_sink()
     # Test that the second row only has sinks
     for point in grid[1]:
         assert point.is_sink()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -355,7 +355,7 @@ def zip_points_and_children(grid, child_locations):
 
 @pytest.mark.parametrize("strategy", (full_recursive, partial_recursive))
 @pytest.mark.parametrize(
-    "grid,expected_child_locations",
+    ("grid", "expected_child_locations"),
     (
         (small_solvable_grid, small_solvable_grid_solution_child_locations),
         (july_12_grid, july_12_grid_solution_child_locations),

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -23,7 +23,7 @@ def test_location_returns_location_when_asked(location):
     assert point.location == location
 
 
-@pytest.mark.parametrize("row_index,column_index", ((0, 0), (0, 1), (1, 2)))
+@pytest.mark.parametrize(("row_index", "column_index"), ((0, 0), (0, 1), (1, 2)))
 def test_indexes_return_correct_values_when_asked(row_index, column_index):
     """Verifies that the index properties return the expected indices."""
     point = Point(None, (row_index, column_index))

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -113,9 +113,8 @@ def test_get_neighbor_with_missing_neighbor_returns_none():
     grid = Grid(((-1, -1, -1), (-1, -1, -1), (-1, -1, -1)))
     # Test the north west point
     point = grid[0][0]
-    assert not (
-        point.has_neighbor(Direction.NORTH) or point.has_neighbor(Direction.WEST)
-    )
+    assert not point.has_neighbor(Direction.NORTH)
+    assert not point.has_neighbor(Direction.WEST)
     assert point.get_neighbor(Direction.NORTH) is None
     # Test the north center point
     point = grid[0][1]
@@ -127,9 +126,8 @@ def test_get_neighbor_with_missing_neighbor_returns_none():
     assert point.get_neighbor(Direction.EAST) is None
     # Test the south east point
     point = grid[2][2]
-    assert not (
-        point.has_neighbor(Direction.EAST) or point.has_neighbor(Direction.SOUTH)
-    )
+    assert not point.has_neighbor(Direction.EAST)
+    assert not point.has_neighbor(Direction.SOUTH)
     assert point.get_neighbor(Direction.EAST) is None
 
 

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -84,7 +84,7 @@ def test_list_returns_expected_direction_order():
 
 
 @pytest.mark.parametrize(
-    "input_string,expected_number",
+    ("input_string", "expected_number"),
     (("", 1), ("a", 1), ("\n", 2), ("a\nb\nc", 3), (GRID_STRING, 5)),
 )
 def test_get_number_of_rows_with_input_string_returns_expected_number(
@@ -96,7 +96,7 @@ def test_get_number_of_rows_with_input_string_returns_expected_number(
 
 
 @pytest.mark.parametrize(
-    "observable,method",
+    ("observable", "method"),
     (
         (Observable(), Observable.notify),
         (MockDerivedObservable(None), MockDerivedObservable.notify),


### PR DESCRIPTION
Adds [flake8-pytest-style](https://github.com/m-burst/flake8-pytest-style) as a development dependency, which in turn automatically includes it among the list of plugins run by Flake8.

In order to ensure compliance between this project and this plugin, some small refactoring changes had to be made to a few tests and a configuration parameter had to be set in the `setup.cfg` file.