### PR TITLE
Change handling of trailing whitespace in existing multiline strings

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -15,11 +15,11 @@ from tests.utility import draw_path
 
 UNSOLVED_GRID_STRING = """\
 3   ·   ·
-         
+         \n\
 ·   2   ·
-         
+         \n\
 *   ·   ·\
-"""  # noqa: W293
+"""
 
 
 SOLVED_GRID_STRING = """\

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -9,11 +9,11 @@ from tests.utility import draw_path
 
 GRID_STRING_1 = """\
 3   ·   ·
-         
+         \n\
 ·   2   ·
-         
+         \n\
 *   ·   ·\
-"""  # noqa: W293
+"""
 
 GRID_STRING_2 = """\
 3---·---·

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -12,19 +12,19 @@ from tests.utility import draw_path
 REVEAL_SEARCH_STRING = """\
 \x1b[J\
 2   ·
-     
+     \n\
 *   *
 \x1b[3A\
 \x1b[J\
 2---·
-     
+     \n\
 *   *
 \x1b[3A\
 \x1b[J\
 2---·
     |
 *   *
-"""  # noqa: W293
+"""
 
 
 def mock_strategy(grid):

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -8,11 +8,11 @@ from gaslines.utility import Direction, Observable, get_number_of_rows
 
 GRID_STRING = """\
 3   ·   ·
-         
+         \n\
 ·   2   ·
-         
+         \n\
 *   ·   ·\
-"""  # noqa: W293
+"""
 
 
 class Incrementor:


### PR DESCRIPTION
Changes the way trailing whitespace in existing multiline strings is handled. In particular, all trailing whitespace in existing multiline strings is no longer also trailing whitespace in the encompassing file.
