### PR TITLE
Refactor constants to use f-strings

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -27,9 +27,7 @@ PROSELINT_IGNORED_PATHS = (
 )
 
 
-PROSELINT_IGNORED_PATHS_REGEX = "^({paths})".format(
-    paths="|".join(PROSELINT_IGNORED_PATHS),
-)
+PROSELINT_IGNORED_PATHS_REGEX = f"^({'|'.join(PROSELINT_IGNORED_PATHS)})"
 
 
 PROSELINT_IGNORED_ERRORS = (
@@ -39,24 +37,21 @@ PROSELINT_IGNORED_ERRORS = (
 )
 
 
-PROSELINT_IGNORED_ERRORS_REGEX = "({errors})".format(
-    errors="|".join(PROSELINT_IGNORED_ERRORS),
-)
+PROSELINT_IGNORED_ERRORS_REGEX = f"({'|'.join(PROSELINT_IGNORED_ERRORS)})"
 
 
 # Shell script that runs proselint on a filtered list of files and then filters out
 # false positive errors
-PROSELINT_CHECK_SCRIPT = """\
-checked_files=$(find . -type f | grep --extended-regexp --invert-match "{p_regex}");
+PROSELINT_CHECK_SCRIPT = f"""\
+checked_files=$(find . -type f | grep --extended-regexp --invert-match \
+"{PROSELINT_IGNORED_PATHS_REGEX}");
 raw_output=$(echo "$checked_files" | xargs proselint);
-output=$(echo "$raw_output" | grep --extended-regexp --invert-match "{e_regex}");
+output=$(echo "$raw_output" | grep --extended-regexp --invert-match \
+"{PROSELINT_IGNORED_ERRORS_REGEX}");
 code=$(expr 1 - $?);
 if [ $code -eq 0 ]; then output="No prose issues found!"; fi
 echo "$output" && exit $code;
-""".format(
-    p_regex=PROSELINT_IGNORED_PATHS_REGEX,
-    e_regex=PROSELINT_IGNORED_ERRORS_REGEX,
-)
+"""
 
 
 # Shell script pipes output from a command to ydiff to enable prettier diff printing

--- a/tasks.py
+++ b/tasks.py
@@ -21,24 +21,26 @@ echo "$output" && exit $code
 """
 
 
+PROSELINT_IGNORED_PATHS = (
+    r"\./\.git/",
+    r"\./\.pytest_cache/",
+)
+
+
 PROSELINT_IGNORED_PATHS_REGEX = "^({paths})".format(
-    paths="|".join(
-        (
-            r"\./\.git/",
-            r"\./\.pytest_cache/",
-        ),
-    ),
+    paths="|".join(PROSELINT_IGNORED_PATHS),
+)
+
+
+PROSELINT_IGNORED_ERRORS = (
+    r"typography\.symbols\.copyright",
+    r"typography\.symbols\.curly_quotes",
+    r"\./\.yamllint\.yaml:18:14: garner\.phrasal_adjectives\.ly",
 )
 
 
 PROSELINT_IGNORED_ERRORS_REGEX = "({errors})".format(
-    errors="|".join(
-        (
-            r"typography\.symbols\.copyright",
-            r"typography\.symbols\.curly_quotes",
-            r"\./\.yamllint\.yaml:18:14: garner\.phrasal_adjectives\.ly",
-        ),
-    ),
+    errors="|".join(PROSELINT_IGNORED_ERRORS),
 )
 
 


### PR DESCRIPTION
Refactors various Proselint constants by replacing the use of `String.format` with f-strings.

This change is made in accordance with Pylint rule C0209, which is enforced on these constants as of at least version 2.12.2, intended to be introduced in PR #151.

I have manually verified that the value of `PROSELINT_CHECK_SCRIPT` has indeed remained constant under these refactors.