### PR TITLE
Validate toml syntax

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -111,6 +111,11 @@ find -E . -type f -iregex '.*\\.(json|lock)' | xargs check-json
 """
 
 
+VALIDATE_TOML_CHECK_COMMAND = """\
+find -E . -type f -iregex '.*(Pipfile|\\.toml)' | xargs check-toml
+"""
+
+
 ERADICATE_SUCCESS_MESSAGE = "No commented-out code found!"
 
 
@@ -177,6 +182,13 @@ CHECKS = collections.OrderedDict(
             REPLACE_EMPTY_STDOUT_SCRIPT.format(
                 command=VALIDATE_JSON_CHECK_COMMAND,
                 message="No json syntax issues found!",
+            ),
+        ),
+        (
+            "validate toml",
+            REPLACE_EMPTY_STDOUT_SCRIPT.format(
+                command=VALIDATE_TOML_CHECK_COMMAND,
+                message="No toml syntax issues found!",
             ),
         ),
         ("black", "black . --check"),


### PR DESCRIPTION
Includes checking toml syntax in the list of checks to run on invocation of the `check` task.

As of these changes, checking the syntax of toml files is now part of the `check` task, which most notably is invoked by the Quality Control GitHub workflow in response to new changes being pushed.
