### PR TITLE
Bump Black version and update dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 invoke = "*"
-black = "==21.12b0"
+black = "*"
 pytest = "*"
 coverage = "*"
 coveralls = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c9933c97433c5fb7f2dd78fc881c7e7530145d09e52f31fddd68ccb16ed42e34"
+            "sha256": "5ee7f95cceae3a61f5c37afd36ceb509e12eef016bba2a363891a2777691b762"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -42,11 +42,32 @@
         },
         "black": {
             "hashes": [
-                "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3",
-                "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"
+                "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b",
+                "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176",
+                "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09",
+                "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a",
+                "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015",
+                "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79",
+                "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb",
+                "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20",
+                "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464",
+                "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968",
+                "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82",
+                "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21",
+                "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0",
+                "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265",
+                "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b",
+                "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a",
+                "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72",
+                "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce",
+                "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0",
+                "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a",
+                "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163",
+                "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad",
+                "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"
             ],
             "index": "pypi",
-            "version": "==21.12b0"
+            "version": "==22.3.0"
         },
         "certifi": {
             "hashes": [
@@ -65,11 +86,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+                "sha256:24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e",
+                "sha256:479707fe14d9ec9a0757618b7a100a0ae4c4e236fac5b7f80ca68028141a1a72"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==7.1.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.2"
         },
         "coverage": {
             "hashes": [
@@ -185,7 +206,7 @@
                 "sha256:1fe43e3e9acf3a7c0f6b88f5338cad37044d2f156c43cb6b080b5f9da8a76f06",
                 "sha256:20fa2a8ca2decac50116edb42e6af0a1253ef639ad79941249b840531889c65a"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_full_version < '4.0.0'",
             "version": "==1.3.2"
         },
         "flake8-pytest-style": {
@@ -205,11 +226,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:8580703d83cf9552489195e9c603047efde56d1551d6df1d22f11055186dc734",
-                "sha256:b8588f4b6511481dd967686db2915104d547899e441af4d670fc1a3051cae573"
+                "sha256:620ffa1782f9cb0b732b66b811d11c3beeb678b96fae947740aaab1dfd74a996",
+                "sha256:8b43dd0154f5918b0faa3f9d59f5552d9c8671073f6b906c797a8505fd5d09c3"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.43.3"
+            "version": "==6.44.0"
         },
         "hypothesmith": {
             "hashes": [
@@ -302,11 +323,38 @@
         },
         "libcst": {
             "hashes": [
-                "sha256:2e1f77fbaaff93b889376c92f588b718edbdc21f956abbe27d10dfd1ff2d76c3",
-                "sha256:330f9082a309bad808e283e80845a843200303bb256690185b98ca458a62c4f8"
+                "sha256:05f97c0f56da7bf8a348d63603a04cdf8f9cc18b9880be62540788e968e4b6fa",
+                "sha256:06de1bc753d789f928f19f5bba5bc83b1b4b304a1b95f537b87c8d5d5cb4b9ce",
+                "sha256:2473609db1218ee3a3d69d39f97e97b65f6fdb90b2bfce0af7680448578ed6eb",
+                "sha256:2bd72ce428ac4123c075cbbacb66ae62ed0c166e248cc81b504779c27e263bb7",
+                "sha256:2f2a2d70f14628eaa2870b94f2c8094048af980754433ac1195af14be3f06e27",
+                "sha256:35194a24918b7386310b3ce02456dc8259a2fdb8ef5c6620132047fb014b4e8e",
+                "sha256:3f61d3be41946d4ed921afb5914e40027d639130771e89d6846c0cc5bee967ec",
+                "sha256:407e419f8f69663509e37c9ebad88ca6ea4904d09a2293f47bbfc7597f82e7db",
+                "sha256:427c88ca77d0c7beb71a0c7f0ea9dccaafad5fc86bb384f381cd8c56412bd0db",
+                "sha256:43f698ee4eeb0fde410a369a4c51c7a5e61974307039ab8ef5c2da83f21b061d",
+                "sha256:46bc765dccd9741951b3716ce8ead0d7014fe5fe04927a5920188aedf786133e",
+                "sha256:640256354d7183bc801a78a5b05238ccdc46b3646c7a7bee288f8cc046ed0b25",
+                "sha256:753ada0471c666befb33ccb73258161bd6493ba3bbb5931abce9d02e71cc673f",
+                "sha256:7aacd83126cf932c38cd58be3f8dd9b9aaa88feaf8aa42418156873a5f5ded70",
+                "sha256:7b2a6be4d8eace4670af9e596b8dd364d74072235e5a17cc7cff1509483a97c8",
+                "sha256:961ab38c0ef318c384a287f1e4f877bb61ce93945f352b14b5dbbe7a317882b1",
+                "sha256:9880a360d9a07283825844d415dc89aee00f13977a571e68f7c168b39a5b7f59",
+                "sha256:9eab2755d4796ac0b89e705133547677eaaacb3a913f6b7761f4dc964cca2886",
+                "sha256:ab268eae8a1fdbc23d510f598d0d5b1efe98d7e4f79045fd565c305adebe3a2d",
+                "sha256:ac37e00960d1ebffbad1b8723d11eaa69371ba49cbcb5680c4da3d50c0536dc3",
+                "sha256:af9526ecc53a515cb5a1761536d6cc6dce7b2ccd958a01d1f185fa580d844afa",
+                "sha256:b4a6bc639bf9f7991e6850329264657448c6516a3d07fe2e0df692ae0bfdac83",
+                "sha256:c5076d07d4f556d82a04654b72ac80c1b38eea4590189c40880202de40ac4237",
+                "sha256:c6bdb278244d35cc5a14275ac1c0c11de79c6df46031f537c7b707b5841dd518",
+                "sha256:ce228e20216bce09ddb4eceed9a669f7fb52568ff300edf99a8850a4d6ab9e86",
+                "sha256:e02d3141ce6960f8df5b3c2615ea112a7a5065a60e81e56ca65a498c2c7f2490",
+                "sha256:ef99c15d0ea671bc1ba914d9f11634748479b1476fd389de9647c918c729d042",
+                "sha256:f8f75ed9981ec9a96835f78809360847661cc9c8033d404dcc65c346ce480f4d",
+                "sha256:fe162be926af39bf307dd69b1ceb89af5ccdbfe21e1d92ba24ef7faa9d62be7b"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.3.23"
+            "version": "==0.4.1"
         },
         "mccabe": {
             "hashes": [
@@ -363,11 +411,11 @@
         },
         "proselint": {
             "hashes": [
-                "sha256:3a87eb393056d1bc77d898e4bcf8998f50e9ad84f7b9ff7cf2720509ac8ef904",
-                "sha256:7db295005d1a2c597ab44b359fea95bb6b92e739784aede69f8ba7098b3c3244"
+                "sha256:5799a26c79e52aed18a1b7671f74381c035b3f62a565b478306298fb134c80c4",
+                "sha256:7dd2b63cc2aa390877c4144fcd3c80706817e860b017f04882fbcd2ab0852a58"
             ],
             "index": "pypi",
-            "version": "==0.10.2"
+            "version": "==0.13.0"
         },
         "py": {
             "hashes": [
@@ -379,11 +427,11 @@
         },
         "pybetter": {
             "hashes": [
-                "sha256:30bf5ffeb3da627cbd053f4d341085cac1dff57acd35a58c32d1c0d9e14a6033",
-                "sha256:9d06800f00f3fdf5b5a899dfa7ffbc2f2dab82b30e8cf96cb6c483a0dc9ab357"
+                "sha256:b431cf1814935485ab1c69e3d24f1eccde4a4d10f1dadcb9ca1144902b6f9c79",
+                "sha256:c7ea10c23a122922eb78f7a799c5c7b29c8f01dbd7171099891e5e4a47a2e969"
             ],
             "index": "pypi",
-            "version": "==0.4.0"
+            "version": "==0.4.1"
         },
         "pycodestyle": {
             "hashes": [
@@ -559,18 +607,18 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f",
-                "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.2.3"
+            "version": "==2.0.1"
         },
         "typing-extensions": {
             "hashes": [
                 "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708",
                 "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"
             ],
-            "markers": "python_version >= '3.10'",
+            "markers": "python_version >= '3.7'",
             "version": "==4.2.0"
         },
         "typing-inspect": {
@@ -586,7 +634,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
             "version": "==1.26.9"
         },
         "vulture": {

--- a/tasks.py
+++ b/tasks.py
@@ -34,6 +34,7 @@ PROSELINT_IGNORED_ERRORS = (
     r"typography\.symbols\.copyright",
     r"typography\.symbols\.curly_quotes",
     r"\./\.yamllint\.yaml:18:14: garner\.phrasal_adjectives\.ly",
+    r"\./tests/test_point\.py:303:13: lexical_illusions\.misc",
 )
 
 


### PR DESCRIPTION
Bumps Black from version `21.12b0` to `22.3.0`, updates all dependencies in the Pipenv lockfile, and adds a new false positive to the proselint ignore list.

This dependency update also releases Black from being fixed to a particular version, since it is now no longer a beta product.
