### PR TITLE
Use grep to filter files in checks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -108,12 +108,16 @@ PYBETTER_FORMAT_COMMAND = "pybetter . --exclude B004"
 
 
 VALIDATE_JSON_CHECK_COMMAND = """\
-find -E . -type f -iregex '.*\\.(json|lock)' | xargs check-json
+find . -type f | \
+grep --ignore-case --extended-regexp '^.*\\.(json|lock)$' | \
+xargs check-json
 """
 
 
 VALIDATE_TOML_CHECK_COMMAND = """\
-find -E . -type f -iregex '.*(Pipfile|\\.toml)' | xargs check-toml
+find . -type f | \
+grep --ignore-case --extended-regexp '^.*(Pipfile|\\.toml)$' | \
+xargs check-toml
 """
 
 


### PR DESCRIPTION
Resolves issue #199 by replacing the use of `find` to filter files in the affected checks with the use of `grep`. Also makes some minor changes to each regex pattern so that the scripts work as expected. I have verified that the new scripts now indeed function as expected.

