### PR TITLE
Remove unnecessarily disabled obsolete Pylint checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,3 @@ skip = suppress
 [pylint]
 max-line-length = 88
 score = no
-
-[pylint.messages_control]
-disable = C0330, C0326


### PR DESCRIPTION
Removes a directive to disable two now obsolete Pylint checks.

These checks were originally disabled in commit fd7bb346620ecb1695e80ecabb362e3bab370dc1 in accordance with [suggestions from Black's documentation](https://github.com/psf/black/blob/22.1.0/docs/guides/using_black_with_other_tools.md#configuration-1). [More recent documentation](https://github.com/psf/black/blob/22.3.0/docs/guides/using_black_with_other_tools.md#why-those-options-above-2), however, claims that the disabling of these checks is not necessary when using Pylint versions >=2.6.0, as in the case of this project. Hence the disabling of these checks can be removed.
