### PR TITLE
Fix Pylint failing to read settings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ lines_after_imports = 2
 # A hacky way to suppress isort's annoying "Skipped x files" comment
 skip = suppress
 
-[pylint]
+[pylint.Format]
 max-line-length = 88
+
+[pylint.Main]
 score = no


### PR DESCRIPTION
Resolves #222 by updating the formatting of Pylint's settings in the `setup.cfg` configuration file.

It is still unclear as to when this issue was initially introduced.
